### PR TITLE
RUBY-646 additional changes that would probably be good

### DIFF
--- a/ext/bson/native.c
+++ b/ext/bson/native.c
@@ -653,7 +653,7 @@ static VALUE rb_string_to_bson_string(VALUE self, VALUE encoded)
 static VALUE rb_string_check_for_illegal_characters(VALUE self)
 {
   if (strlen(RSTRING_PTR(self)) != (size_t) RSTRING_LEN(self))
-    rb_raise(rb_eRuntimeError, "Illegal C-String contains a null byte.");
+    rb_raise(rb_eArgError, "Illegal C-String contains a null byte.");
   return self;
 }
 

--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -168,7 +168,7 @@ module BSON
 
     def check_for_illegal_characters!
       if include?(NULL_BYTE)
-        raise RuntimeError.new("Illegal C-String '#{self}' contains a null byte.")
+        raise(ArgumentError, "Illegal C-String '#{self}' contains a null byte.")
       end
     end
 

--- a/spec/bson/string_spec.rb
+++ b/spec/bson/string_spec.rb
@@ -65,7 +65,7 @@ describe String do
       it "raises an error" do
         expect {
           string.to_bson_cstring
-        }.to raise_error(RuntimeError)
+        }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/bson/symbol_spec.rb
+++ b/spec/bson/symbol_spec.rb
@@ -48,7 +48,7 @@ describe Symbol do
       it 'raises an error' do
         expect {
           symbol.to_bson_key
-        }.to raise_error(RuntimeError)
+        }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
We already call `String#check_for_illegal_characters!` in `#to_bson_cstring` and I added a test for the fix I made in the previous pull request. 
