### PR TITLE
RUBY-714 fixing missing require for time in bson/date_time

### DIFF
--- a/lib/bson/date_time.rb
+++ b/lib/bson/date_time.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "time"
+
 module BSON
 
   # Injects behaviour for encoding date time values to raw bytes as specified by


### PR DESCRIPTION
Props to @tylerbrock for catching this one, but the most recent version of bson is missing a needed require for `time` in `bson/date_time`. This is raising an exception for anyone trying to use this gem outside of an environment where that's already in the loaded.

I'd like to get this patched and push a 2.1.1 today to address this. Will do that as soon as this is :+1:  and merged.
