### PR TITLE
Fix RUBY_ENGINE on ruby 1.8

### DIFF
--- a/lib/bson/environment.rb
+++ b/lib/bson/environment.rb
@@ -42,6 +42,7 @@ module BSON
     #
     # @since 2.1.0
     def ree?
+      return false unless defined?(RUBY_ENGINE)
       RUBY_ENGINE == "ruby" && RUBY_DESCRIPTION =~ /Enterprise/
     end
 


### PR DESCRIPTION
Fix bson-ruby under ruby 1.8.

I hope this turns 1.8 green, and we might want not `allow_failures` on it anymore.
`RUBY_ENGINE` is not defined on ruby 1.8, so we cannot use it.

review @durran @brandonblack
