### PR TITLE
Fix Time encoding

### DIFF
--- a/lib/bson/time.rb
+++ b/lib/bson/time.rb
@@ -38,7 +38,7 @@ module BSON
     #
     # @since 2.0.0
     def to_bson(encoded = ''.force_encoding(BINARY))
-      encoded << [ (to_f * 1000.0).to_i ].pack(Int64::PACK)
+      encoded << [ (to_i * 1000) + (usec / 1000) ].pack(Int64::PACK)
     end
 
     module ClassMethods

--- a/spec/bson/time_spec.rb
+++ b/spec/bson/time_spec.rb
@@ -24,8 +24,8 @@ describe Time do
 
     context "when the time is post epoch" do
 
-      let(:obj)  { Time.utc(2012, 1, 1, 0, 0, 0) }
-      let(:bson) { [ (obj.to_f * 1000).to_i ].pack(BSON::Int64::PACK) }
+      let(:obj)  { Time.at(Time.utc(2014,03,22,18,05,05).to_i, 505000).utc }
+      let(:bson) { [ (obj.to_i * 1000) + (obj.usec / 1000) ].pack(BSON::Int64::PACK) }
 
       it_behaves_like "a serializable bson element"
       it_behaves_like "a deserializable bson element"


### PR DESCRIPTION
Hi,

This is a resulting of a yak shave for the following issue:
https://github.com/mongoid/mongoid/pull/3563

The previous code was causing rounding errors. The result for us was when using `Mongoid::Timestamps` in embedded documents, the query sent to mongodb when deleting documents is a `$pullAll` with its `created_at` and `updated_at` fields which were badly BSON encoded. For every documents where the rounding error occurred, they were never deleted with a `delete_all` or `destroy_all` method call.

The Time I used in the updated spec is one causing this rounding error. You can test the old line bson encoding line with it to see the test actually fail.

This also fixes DateTime as it is converted to a Time when to_bson is called on it.
