### PR TITLE
Rename Generator#next to Generator#next_object_id.

### DIFF
--- a/ext/bson/native.c
+++ b/ext/bson/native.c
@@ -703,6 +703,6 @@ void Init_native()
   rb_define_private_method(string, "check_for_illegal_characters!", rb_string_check_for_illegal_characters, 0);
 
   // Redefine the next method on the object id generator.
-  rb_undef_method(generator, "next");
-  rb_define_method(generator, "next", rb_object_id_generator_next, -1);
+  rb_undef_method(generator, "next_object_id");
+  rb_define_method(generator, "next_object_id", rb_object_id_generator_next, -1);
 }

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -170,7 +170,7 @@ module BSON
     # @since 2.0.0
     def to_bson(encoded = ''.force_encoding(BINARY))
       repair if defined?(@data)
-      @raw_data ||= @@generator.next
+      @raw_data ||= @@generator.next_object_id
       encoded << @raw_data
     end
 
@@ -268,7 +268,7 @@ module BSON
       #
       # @since 2.0.0
       def from_time(time, options = {})
-        from_data(options[:unique] ? @@generator.next(time.to_i) : [ time.to_i ].pack("Nx8"))
+        from_data(options[:unique] ? @@generator.next_object_id(time.to_i) : [ time.to_i ].pack("Nx8"))
       end
 
       # Determine if the provided string is a legal object id.
@@ -337,14 +337,14 @@ module BSON
       # object id counter. Will use the provided time if not nil.
       #
       # @example Get the next object id data.
-      #   generator.next
+      #   generator.next_object_id
       #
       # @param [ Time ] time The optional time to generate with.
       #
       # @return [ String ] The raw object id bytes.
       #
       # @since 2.0.0
-      def next(time = nil)
+      def next_object_id(time = nil)
         @mutex.lock
         begin
           count = @counter = (@counter + 1) % 0xFFFFFF


### PR DESCRIPTION
Ruby 2.1.0 doesn't allow overriding native keywords.
