### PR TITLE
[ RUBY-761 ] Normalize symbol keys into strings.

### DIFF
--- a/lib/bson/array.rb
+++ b/lib/bson/array.rb
@@ -68,6 +68,18 @@ module BSON
       ObjectId.repair(self) { pack("C*") }
     end
 
+    # Converts the array to a normalized value in a BSON document.
+    #
+    # @example Convert the array to a normalized value.
+    #   array.to_bson_normalized_value
+    #
+    # @return [ Array ] The normazlied array.
+    #
+    # @since 3.0.0
+    def to_bson_normalized_value
+      map!{ |value| value.to_bson_normalized_value }
+    end
+
     module ClassMethods
 
       # Deserialize the array from BSON.

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -50,10 +50,10 @@ module BSON
     #
     # @since 2.0.0
     def [](key)
-      super(normalize_key(key))
+      super(key.to_bson_normalized_key)
     end
 
-    # Set a value on the document. Will normalize_key symbol keys into strings.
+    # Set a value on the document. Will normalize symbol keys into strings.
     #
     # @example Set a value on the document.
     #   document[:test] = "value"
@@ -65,7 +65,7 @@ module BSON
     #
     # @since 3.0.0
     def []=(key, value)
-      super(normalize_key(key), value)
+      super(key.to_bson_normalized_key, value.to_bson_normalized_value)
     end
 
     # Instantiate a new Document. Valid parameters for instantiation is a hash
@@ -110,18 +110,12 @@ module BSON
     # @since 3.0.0
     def merge!(other)
       other.each_pair do |key, value|
-        value = yield(normalize_key(key), self[key], value) if block_given?
+        value = yield(key.to_bson_normalized_key, self[key], value.to_bson_normalized_value) if block_given?
         self[key] = value
       end
       self
     end
 
     alias :update :merge!
-
-    private
-
-    def normalize_key(key)
-      key.is_a?(::Symbol) ? key.to_s : key
-    end
   end
 end

--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -48,6 +48,18 @@ module BSON
       end
     end
 
+    # Converts the hash to a normalized value in a BSON document.
+    #
+    # @example Convert the hash to a normalized value.
+    #   hash.to_bson_normalized_value
+    #
+    # @return [ BSON::Document ] The normazlied hash.
+    #
+    # @since 3.0.0
+    def to_bson_normalized_value
+      Document.new(self)
+    end
+
     module ClassMethods
 
       # Deserialize the hash from BSON.

--- a/lib/bson/object.rb
+++ b/lib/bson/object.rb
@@ -34,6 +34,30 @@ module BSON
     def to_bson_key(encoded = ''.force_encoding(BINARY))
       raise InvalidKey.new(self)
     end
+
+    # Converts the object to a normalized key in a BSON document.
+    #
+    # @example Convert the object to a normalized key.
+    #   object.to_bson_normalized_key
+    #
+    # @return [ Object ] self.
+    #
+    # @since 3.0.0
+    def to_bson_normalized_key
+      self
+    end
+
+    # Converts the object to a normalized value in a BSON document.
+    #
+    # @example Convert the object to a normalized value.
+    #   object.to_bson_normalized_value
+    #
+    # @return [ Object ] self.
+    #
+    # @since 3.0.0
+    def to_bson_normalized_value
+      self
+    end
   end
 
   # Raised when trying to serialize an object into a key.

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -58,6 +58,18 @@ module BSON
       to_s.to_bson_key(encoded)
     end
 
+    # Converts the symbol to a normalized key in a BSON document.
+    #
+    # @example Convert the symbol to a normalized key.
+    #   :test.to_bson_normalized_key
+    #
+    # @return [ String ] The symbol as a non interned string.
+    #
+    # @since 3.0.0
+    def to_bson_normalized_key
+      to_s
+    end
+
     module ClassMethods
       # Deserialize a symbol from BSON.
       #

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -538,6 +538,39 @@ describe BSON::Document do
         expect(document[:test]).to eq(4)
       end
     end
+
+    context "when providing a nested hash with symbol keys" do
+
+      let(:document) do
+        described_class.new(:test => { :test => 4 })
+      end
+
+      it "converts the nested keys to strings" do
+        expect(document).to eq({ "test" => { "test" => 4 }})
+      end
+    end
+
+    context "when providing a nested hash multiple levels deep with symbol keys" do
+
+      let(:document) do
+        described_class.new(:test => { :test => { :test => 4 }})
+      end
+
+      it "converts the nested keys to strings" do
+        expect(document).to eq({ "test" => { "test" => { "test" => 4 }}})
+      end
+    end
+
+    context "when providing an array of nested hashes" do
+
+      let(:document) do
+        described_class.new(:test => [{ :test => 4 }])
+      end
+
+      it "converts the nested keys to strings" do
+        expect(document).to eq({ "test" => [{ "test" => 4 }]})
+      end
+    end
   end
 
   describe "#replace" do


### PR DESCRIPTION
Like Active Support's `HashWithIndifferentAccess`

Note that I added the methods `to_bson_normalized_key` and `to_bson_normalized_value` on `Object` with specific implementations on `Symbol`, `Hash`, and `Array`. The reason for this was performance related in that 1) We don't have to walk the object hierarchy when doing `object.is_a?(Symbol)` and 2) converting nested values like `Array` and `Hash` don't require a case statement or if/else/if.

cc/ @estolfo @gjmurakami-10gen @samantharitter

https://jira.mongodb.org/browse/RUBY-761
