### PR TITLE
Raise an exception for invalid UTF-8

### DIFF
--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -762,20 +762,6 @@ describe BSON::Document do
       it_behaves_like "a document able to handle utf-8"
     end
 
-    context "when non utf-8 values exist" do
-
-      let(:string) { "gültig" }
-      let(:document) do
-        described_class["type", string.encode("iso-8859-1")]
-      end
-
-      it "encodes and decodes the document properly" do
-        expect(
-          BSON::Document.from_bson(StringIO.new(document.to_bson))
-        ).to eq({ "type" => string })
-      end
-    end
-
     context "when binary strings with utf-8 values exist" do
 
       let(:string) { "europäischen" }

--- a/spec/bson/string_spec.rb
+++ b/spec/bson/string_spec.rb
@@ -90,27 +90,6 @@ describe String do
       it_behaves_like "a binary encoded string"
     end
 
-    context "when the string is encoded in non utf-8" do
-
-      let(:string) do
-        "Straße".encode("iso-8859-1")
-      end
-
-      let(:encoded) do
-        string.to_bson_cstring
-      end
-
-      let(:char) do
-        "ß".chr.force_encoding(BSON::BINARY)
-      end
-
-      it "returns the encoded string" do
-        expect(encoded).to eq("Stra#{char}e#{BSON::NULL_BYTE}")
-      end
-
-      it_behaves_like "a binary encoded string"
-    end
-
     context "when the string contains non utf-8 characters" do
 
       let(:string) do
@@ -218,31 +197,23 @@ describe String do
       it_behaves_like "a binary encoded string"
     end
 
-    context "when the string is encoded in non utf-8" do
-
-      let(:string) do
-        "Straße".encode("iso-8859-1")
-      end
-
-      let(:encoded) do
-        string.to_bson_string
-      end
-
-      let(:char) do
-        "ß".chr.force_encoding(BSON::BINARY)
-      end
-
-      it "returns the encoded string" do
-        expect(encoded).to eq("Stra#{char}e")
-      end
-
-      it_behaves_like "a binary encoded string"
-    end
-
     context "when the string contains non utf-8 characters" do
 
       let(:string) do
         255.chr
+      end
+
+      it "raises an error" do
+        expect {
+          string.to_bson_string
+        }.to raise_error(EncodingError)
+      end
+    end
+
+    context "when the string is not valid utf-8" do
+
+      let(:string) do
+        "\xED\xAE\xBA\xED\xB6\x86"
       end
 
       it "raises an error" do


### PR DESCRIPTION
This needs to be cleaned up still, but it works...

Same issue as the one logged in this ticket: https://jira.mongodb.org/browse/RUBY-779
