### PR TITLE
Fix decoding a signed int from bson under rubinius. 

### DIFF
--- a/ext/bson/native.c
+++ b/ext/bson/native.c
@@ -356,7 +356,7 @@ static VALUE rb_integer_to_bson_key(int argc, VALUE *argv, VALUE self)
 static VALUE rb_integer_from_bson_int32(VALUE self, VALUE bson)
 {
   const uint8_t *v = (const uint8_t*) RSTRING_PTR(bson);
-  const uint32_t integer = v[0] + (v[1] << 8) + (v[2] << 16) + (v[3] << 24);
+  const int32_t integer = v[0] + (v[1] << 8) + (v[2] << 16) + (v[3] << 24);
   return INT2NUM(integer);
 }
 

--- a/spec/bson/int32_spec.rb
+++ b/spec/bson/int32_spec.rb
@@ -25,4 +25,18 @@ describe BSON::Int32 do
     it_behaves_like "a bson element"
     it_behaves_like "a deserializable bson element"
   end
+
+  describe "when the integer is negative" do
+    let(:decoded) { -1 }
+    let(:encoded) {StringIO.new([ -1 ].pack(BSON::Int32::PACK))}
+    let(:decoded_2) { -1 }
+    let(:encoded_2) {StringIO.new([ -1 ].pack(BSON::Int32::PACK))}
+    it "decodes a -1 correctly" do
+      expect(BSON::Int32.from_bson(encoded)).to eq(decoded)
+    end  
+    it "decodes a -50 correctly" do
+      expect(BSON::Int32.from_bson(encoded_2)).to eq(decoded_2)
+    end  
+  end
+  
 end


### PR DESCRIPTION
INT2NUM is implmented differently. and the result is MAX_INT for -1, this corrects the issue and also ensures signed behaviour under all rubies
