### PR TITLE
A shortcut to BSON::ObjectId.from_string

### DIFF
--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -96,6 +96,13 @@ module BSON
     def to_bson_object_id
       ObjectId.repair(self)
     end
+    
+    # A shortcut to BSON::ObjectId.from_string('048fec556265664f5b110000')
+    # @example Convert the string to an object id.
+    #   '048fec556265664f5b110000'.to_object_id
+    def to_object_id
+      BSON::ObjectId.from_string(self)
+    end
 
     # Convert the string to a UTF-8 string then force to binary. This is so
     # we get errors for strings that are not UTF-8 encoded.


### PR DESCRIPTION
A shortcut to BSON::ObjectId.from_string('048fec556265664f5b110000') instead this, just use '048fec556265664f5b110000'.to_object_id