### PR TITLE
Implements BSON::Binary#inspect.

### DIFF
--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -96,6 +96,18 @@ module BSON
       @type = type
     end
 
+    # Get a nice string for use with object inspection.
+    #
+    # @example Inspect the binary.
+    #   object_id.inspect
+    #
+    # @return [ String ] The binary in form BSON::Binary:object_id
+    #
+    # @since 2.3.0
+    def inspect
+      "BSON::Binary:#{object_id}"
+    end
+
     # Encode the binary type
     #
     # @example Encode the binary.


### PR DESCRIPTION
With the current implementation of `inspect` writing a lot of
binary data results in *huge* log files. This commit fixes the
problem by returning only `BSON::Binary:"object_id"`.