### PR TITLE
Issue when using a binary field with mongoid

### DIFF
--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -117,7 +117,7 @@ module BSON
     #
     # @since 2.3.0
     def inspect
-      "<BSON::Binary:0x#{object_id} type=#{type} data=#{data[0, 8]}...>"
+      "<BSON::Binary:0x#{object_id} type=#{type} data=#{data[0, 8].unpack('H*')}...>"
     end
 
     # Encode the binary type

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -117,7 +117,7 @@ module BSON
     #
     # @since 2.3.0
     def inspect
-      "<BSON::Binary:0x#{object_id} type=#{type} data=#{data[0, 8].unpack('H*')}...>"
+      "<BSON::Binary:0x#{object_id} type=#{type} data=0x#{data[0, 8].unpack('H*').first}...>"
     end
 
     # Encode the binary type

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -91,7 +91,7 @@ describe BSON::Binary do
     end
 
     it 'returns the truncated data and type' do
-      expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=[\"74657374696e6731\"]...>")
+      expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=0x74657374696e6731...>")
     end
 
     context 'with other encoding' do
@@ -101,7 +101,7 @@ describe BSON::Binary do
       end
 
       it 'returns the truncated data and type' do
-        expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=[\"1f8b08000c787055\"]...>")
+        expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=0x1f8b08000c787055...>")
       end
 
       it 'is not different from default encoding' do

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -91,8 +91,25 @@ describe BSON::Binary do
     end
 
     it 'returns the truncated data and type' do
-      expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=testing1...>")
+      expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=[\"74657374696e6731\"]...>")
     end
+
+    context 'with other encoding' do
+
+      let(:object) do
+        described_class.new("\x1F\x8B\b\x00\fxpU\x00\x03\xED\x1C\xDBv\xDB6\xF2\xBD_\x81UN\x9A\xE6T\x96H\xDD-\xDBjR7\xDD\xA6mR\x9F:m\xB7".force_encoding(Encoding::BINARY), :user)
+      end
+
+      it 'returns the truncated data and type' do
+        expect(object.inspect).to eq("<BSON::Binary:0x#{object.object_id} type=user data=[\"1f8b08000c787055\"]...>")
+      end
+
+      it 'is not different from default encoding' do
+        expect(object.inspect.encoding).not_to eq(Encoding::BINARY)
+      end
+
+    end
+
   end
 
   describe "#to_bson/#from_bson" do


### PR DESCRIPTION
After your recent changes we are not able to use a binary field with mongoid.

We used ActiveSupport::Gzip to compress a string, then we have a binary encoded to ascii-8bit, which is the default encoding for a binary, but when mongoid call your ".inspect" method, it raises because incompatible encoding type. It was expected to get utf8 encoding but receives ascii8-bit.