### PR TITLE
Allow BSON::Regexp to delegate methods to Regexp

### DIFF
--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -120,6 +120,21 @@ module BSON
         @pattern = pattern
         @options = options
       end
+
+      # Allow automatic delegation of methods to the Regexp object
+      # returned by +compile+.
+      #
+      # @param [ String] method The name of a method.
+      def respond_to?(method)
+        compile.respond_to?(method) || super
+      end
+
+      # Delegates all method calls that are not handled by this object
+      # to the Regexp returned by +compile+.
+      def method_missing(method, *arguments)
+        return super unless respond_to?(method)
+        compile.send(method)
+      end
     end
 
     module ClassMethods

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -46,6 +46,22 @@ describe Regexp do
 
     it_behaves_like "a bson element"
 
+    context "when calling normal regexp methods on a Regexp::Raw" do
+      let :obj do
+        /\d+/
+      end
+
+      let :bson do
+        [obj.source, BSON::NULL_BYTE, BSON::NULL_BYTE].join ''
+      end
+
+      it_behaves_like "a serializable bson element"
+
+      it "runs the method on the Regexp object" do
+        expect(result.match('6')).not_to be_nil
+      end
+    end
+
     context "when the regexp has no options" do
 
       let(:obj)  { /\d+/ }


### PR DESCRIPTION
Ruby's Regexp method allows for a ton of methods that BSON::Regexp::Raw
does not define. This change lets any method not defined by the
BSON::Regexp::Raw class to be delegated to the underlying Regexp object
provided by BSON::Regexp::Raw#compile. It should cut down on boilerplate
code on the app level that allows you to use a BSON::Regexp::Raw as a Regexp,
by calling methods like match(), scan(), etc.