### PR TITLE
add support for ActiveSupport Hash#slice method

### DIFF
--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -50,7 +50,7 @@ module BSON
     #
     # @since 2.0.0
     def [](key)
-      super(key.to_bson_normalized_key)
+      super(convert_key(key))
     end
 
     # Set a value on the document. Will normalize symbol keys into strings.
@@ -65,7 +65,7 @@ module BSON
     #
     # @since 3.0.0
     def []=(key, value)
-      super(key.to_bson_normalized_key, value.to_bson_normalized_value)
+      super(convert_key(key), convert_value(value))
     end
 
     # Instantiate a new Document. Valid parameters for instantiation is a hash
@@ -110,12 +110,22 @@ module BSON
     # @since 3.0.0
     def merge!(other)
       other.each_pair do |key, value|
-        value = yield(key.to_bson_normalized_key, self[key], value.to_bson_normalized_value) if block_given?
+        value = yield(convert_key(key), self[key], convert_value(value)) if block_given?
         self[key] = value
       end
       self
     end
 
     alias :update :merge!
+
+    private
+
+    def convert_key(key)
+      key.to_bson_normalized_key
+    end
+
+    def convert_value(value)
+      value.to_bson_normalized_value
+    end
   end
 end


### PR DESCRIPTION
A common practice in rails is to `#slice` hash by array of symbols. `#slice` [expects](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/hash/slice.rb#L22) any conversion on key to happen in `#convert_key` method. That was made to support `HashWithIndifferentAccess`. [Implementation of `#convert_key` in HashWithIndifferentAccess](https://github.com/rails/rails/blob/3e36db4406beea32772b1db1e9a16cc1e8aea14c/activesupport/lib/active_support/hash_with_indifferent_access.rb#L258)

before this changes:
```ruby
bson_doc = BSON::Document.new(hello: 'world')
bson_doc.slice(:hello) # => {}
```
after this changes:
```ruby
bson_doc = BSON::Document.new(hello: 'world')
bson_doc.slice(:hello) # => {'hello' => 'world'}
```