### PR TITLE
Fix ArgumentError in BSON::Regexp::Ruby

### DIFF
--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -135,7 +135,7 @@ module BSON
 
       def method_missing(method, *arguments)
         return super unless respond_to?(method)
-        compile.send(method)
+        compile.send(method, *arguments)
       end
     end
 


### PR DESCRIPTION
When a user attempts to call a method on BSON::Regexp::Ruby with arguments, an ArgumentError will be thrown. This change will actually pass down the arguments so that such errors will not get raised. Sorry about not passing the `*arguments` the first time...