### PR TITLE
Fix ArgumentError in BSON::Regexp::Ruby

### DIFF
--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -135,7 +135,7 @@ module BSON
 
       def method_missing(method, *arguments)
         return super unless respond_to?(method)
-        compile.send(method)
+        compile.send(method, *arguments)
       end
     end
 

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -40,8 +40,12 @@ describe Regexp do
       StringIO.new(bson)
     end
 
+    let(:regex) do
+      described_class.from_bson(io)
+    end
+
     let(:result) do
-      described_class.from_bson(io).compile
+      regex.compile
     end
 
     it_behaves_like "a bson element"
@@ -58,7 +62,7 @@ describe Regexp do
       it_behaves_like "a serializable bson element"
 
       it "runs the method on the Regexp object" do
-        expect(result.match('6')).not_to be_nil
+        expect(regex.match('6')).not_to be_nil
       end
     end
 


### PR DESCRIPTION
When a user attempts to call a method on BSON::Regexp::Ruby with arguments, an ArgumentError will be thrown. This change will actually pass down the arguments so that such errors will not get raised.