### PR TITLE
BSON::ObjectId#inspect returns a string that evals into an object id

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -19,6 +19,22 @@ require "bson/environment"
 # @since 0.0.0
 module BSON
 
+  # Create a new object id from a string using ObjectId.from_string
+  #
+  # @example Create an object id from the string.
+  #   BSON::ObjectId(id)
+  #
+  # @param [ String ] string The string to create the id from.
+  #
+  # @raise [ BSON::ObjectId::Invalid ] If the provided string is invalid.
+  #
+  # @return [ BSON::ObjectId ] The new object id.
+  #
+  # @see ObjectId.from_string
+  def self.ObjectId(string)
+    self::ObjectId.from_string(string)
+  end
+
   # Constant for binary string encoding.
   #
   # @since 2.0.0

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -124,7 +124,7 @@ module BSON
     #
     # @since 2.0.0
     def inspect
-      "<BSON::ObjectId:0x#{object_id} data=#{to_s}>"
+      "BSON::ObjectId('#{to_s}')"
     end
 
     # Dump the raw bson when calling Marshal.dump.

--- a/spec/bson/object_id_spec.rb
+++ b/spec/bson/object_id_spec.rb
@@ -390,7 +390,11 @@ describe BSON::ObjectId do
     end
 
     it "returns the inspection with the object id to_s" do
-      expect(object_id.inspect).to eq("<BSON::ObjectId:0x#{object_id.object_id} data=#{object_id.to_s}>")
+      expect(object_id.inspect).to eq("BSON::ObjectId('#{object_id.to_s}')")
+    end
+
+    it "returns a string that evaluates into an equivalent object id" do
+      expect(eval object_id.inspect).to eq object_id
     end
   end
 

--- a/spec/bson_spec.rb
+++ b/spec/bson_spec.rb
@@ -16,6 +16,16 @@ require "spec_helper"
 
 describe BSON do
 
+  describe ".ObjectId" do
+
+    let(:string) { "4e4d66343b39b68407000001" }
+
+    it "returns an BSON::ObjectId from given string" do
+      expect(described_class::ObjectId(string)).to be_a BSON::ObjectId
+      expect(described_class::ObjectId(string)).to eq BSON::ObjectId.from_string(string)
+    end
+  end
+
   describe "::BINARY" do
 
     it "returns BINARY" do


### PR DESCRIPTION
This will let `BSON::ObjectId#inspect` to return a string that can be evaluated into an equivalent object id. This would be super useful for copying and pasting object ids (especially when used with **Mongoid**).

A `BSON.ObjectId` constructor method passes the argument to `#from_string`, allowing object ids to behave kinda like literals.

Seemingly sending an arg to a constant as a constructor is similar to some behavior found in the standard lib: `Pathname('./lib')` or `Hash(a: 1, b: 2)`

If this is helpful, perhaps something similar can be implemented for `BSON::Binary` as well.

**Now**
``` ruby
>> BSON::ObjectId.new
=> BSON::ObjectId('559afa3e546f6e2631000000')

>> BSON::ObjectId('559afa3e546f6e2631000000')
=> BSON::ObjectId('559afa3e546f6e2631000000')
😃😃😃😃

# Mongoid
>> Song.first.attributes
=> {"_id"=>BSON::ObjectId('559b0037546f6e28440a0000'),
   "length"=>219,
   "name"=>"Shake It Off",
   "artist_id"=>BSON::ObjectId('559afff3546f6e2844030000'),
   "album_id"=>BSON::ObjectId('559aff93546f6e2844020000')}

>> {"_id"=>BSON::ObjectId('559b0037546f6e28440a0000'), "length"=>219, "name"=>"Shake It Off", "artist_id"=>BSON::ObjectId('559afff3546f6e2844030000'), "album_id"=>BSON::ObjectId('559aff93546f6e2844020000')}
=> {"_id"=>BSON::ObjectId('559b0037546f6e28440a0000'),
   "length"=>219,
   "name"=>"Shake It Off",
   "artist_id"=>BSON::ObjectId('559afff3546f6e2844030000'),
   "album_id"=>BSON::ObjectId('559aff93546f6e2844020000')}
```

**Before** (https://github.com/mongodb/bson-ruby/commit/990c7157)
``` ruby
>> BSON::ObjectId.new
=> <BSON::ObjectId:0x70280035828000 data=559afa3e546f6e2631000000>

>> <BSON::ObjectId:0x70280035828000 data=559afa3e546f6e2631000000>
😡 SyntaxError: unexpected '<', expecting end-of-input
```

**Way Before** (https://github.com/mongodb/bson-ruby/commit/27d9a915)
``` ruby
>> BSON::ObjectId.new
=> BSON::ObjectId('559afa3e546f6e2631000000')

>> BSON::ObjectId('559afa3e546f6e2631000000')
😡 NoMethodError: undefined method `ObjectId' for BSON:Module
```
Hope this helps!