### PR TITLE
Added big endian support into the native code

### DIFF
--- a/perf/bench.rb
+++ b/perf/bench.rb
@@ -107,8 +107,8 @@ def benchmark!
     end
 
     false_bytes = false.to_bson
-    bench.report("Binary#from_bson ------>") do
-      count.times { BSON::Binary.from_bson(StringIO.new(false_bytes)) }
+    bench.report("Boolean#from_bson ----->") do
+      count.times { BSON::Boolean.from_bson(StringIO.new(false_bytes)) }
     end
 
     max_key_bytes = BSON::MaxKey.new.to_bson

--- a/spec/bson/timestamp_spec.rb
+++ b/spec/bson/timestamp_spec.rb
@@ -65,7 +65,7 @@ describe BSON::Timestamp do
 
     let(:type) { 17.chr }
     let(:obj)  { described_class.new(1, 10) }
-    let(:bson) { [ 10, 1 ].pack("l2") }
+    let(:bson) { [ 10, 1 ].pack(BSON::Int32::PACK * 2) }
 
     it_behaves_like "a bson element"
     it_behaves_like "a serializable bson element"


### PR DESCRIPTION
Added big endian support into the native code. Additionally corrected two issues common to all processor architecures:
  1)  In the spec/bson/timestamp_spec.rb where the "#to_bson/#from_bson" test, the pack as was specified as ("l2") instead of (BSON::Int32::PACK * 2) 
  2) In the benchmarking code, the FalseClass was being incorrectly bench marked against a BSON::Binary rather than a BSON::Boolean
