### PR TITLE
Fix Regexp.from_bson for data from SSL connections

### DIFF
--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -153,13 +153,13 @@ module BSON
       def from_bson(bson)
         pattern = bson.gets(NULL_BYTE).from_bson_string.chop!
         options = 0
-        while (option = bson.readbyte) != 0
+        while (option = bson.readbyte.chr) != NULL_BYTE
           case option
-          when 105 # 'i'
+          when "i"
             options |= ::Regexp::IGNORECASE
-          when 109, 115 # 'm', 's'
+          when "m", "s"
             options |= ::Regexp::MULTILINE
-          when 120 # 'x'
+          when "x"
             options |= ::Regexp::EXTENDED
           end
         end


### PR DESCRIPTION
This PR unifies parsing of regular expressions across SSL and non-SSL connections thus fixing [RUBY-1048](https://jira.mongodb.org/browse/RUBY-1048). From the issue description:

> When accessing mongodb through SSL, Regexp attributes can't be read from the database. https://github.com/mongodb/bson-ruby/blob/master/lib/bson/regexp.rb#L156 hangs indefinitely as the options are NULL_BYTE terminated.

> Note that this issue only occurs when connecting through SSL. On an unencrypted connection, options are indeed "0" terminated and the bug thus doesn't manifest itself using non-encrypted connections.

> The parsing of the options itself is also subject to differences between SSL and non-SSL connections.

> Test case in Rails:

> ```ruby
class TestRecord
  include Mongoid::Document
  field :regex, type: Regexp
end 
> 
> TestRecord.create(regex: //).reload # Will never return when connecting to MongoDB through SSL
```