### PR TITLE
Support symbols for BSON::Document has_key?, has_value?

### DIFF
--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -68,6 +68,39 @@ module BSON
       super(convert_key(key), convert_value(value))
     end
 
+    # Returns true if the given key is present in the document.  Will normalize
+    # symbol keys into strings.
+    #
+    # @example Test if a key exists using a symbol
+    #   document.has_key?(:test)
+    #
+    # @return [ true, false]
+    #
+    # @since 3.2.7
+    def has_key?(key)
+      super(convert_key(key))
+    end
+
+    alias :include? :has_key?
+    alias :key?     :has_key?
+    alias :member?  :has_key?
+
+
+    # Returns true if the given value is present in the document.  Will normalize
+    # symbols into strings.
+    #
+    # @example Test if a key exists using a symbol
+    #   document.has_value?(:test)
+    #
+    # @return [ true, false]
+    #
+    # @since 3.2.7
+    def has_value?(value)
+      super(convert_value(value))
+    end
+
+    alias :value :has_value?
+
     # Instantiate a new Document. Valid parameters for instantiation is a hash
     # only or nothing.
     #

--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module BSON
-  VERSION = "3.2.6"
+  VERSION = "3.2.7"
 end

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -159,6 +159,20 @@ describe BSON::Document do
           expect(doc.send(method, "indigo")).to be false
         end
       end
+
+      context "when the key exists and is requested with a symbol" do
+
+        it "returns true" do
+          expect(doc.send(method, :blue)).to be true
+        end
+      end
+
+      context "when the key does not exist and is requested with a symbol" do
+
+        it "returns false" do
+          expect(doc.send(method, :indigo)).to be false
+        end
+      end
     end
   end
 

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -180,6 +180,13 @@ describe BSON::Document do
 
     describe "##{method}" do
 
+      let(:key) { :purple }
+      let(:val) { :'5422a8' }
+
+      before do
+        doc[key] = val
+      end
+
       context "when the value exists" do
 
         it "returns true" do
@@ -191,6 +198,21 @@ describe BSON::Document do
 
         it "returns false" do
           expect(doc.send(method, "ABCABC")).to be false
+        end
+      end
+
+      context "when the value exists and is requested with a symbol" do
+
+        it "returns true" do
+
+          expect(doc.send(method, :'5422a8')).to be true
+        end
+      end
+
+      context "when the value does not exist and is requested with a symbol" do
+
+        it "returns false" do
+          expect(doc.send(method, :ABCABC)).to be false
         end
       end
     end


### PR DESCRIPTION
* Coerce passed symbols to strings for `has_key?` and `has_value?` methods
* Add standard aliases
* Update tests
* Increment version