### PR TITLE
RUBY-1071 Integer#to_bson_key should return a string to be consistent with other classes

### DIFF
--- a/lib/bson/integer.rb
+++ b/lib/bson/integer.rb
@@ -145,8 +145,8 @@ module BSON
       encoded << ((self >> 56) & 255)
     end
 
-    def to_bson_key(buffer = ByteBuffer.new)
-      buffer.put_cstring(to_s)
+    def to_bson_key
+      to_s
     end
 
     private

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -37,6 +37,21 @@ describe Hash do
       it_behaves_like "a deserializable bson element"
     end
 
+    context "when the hash has non-string keys" do
+
+      let(:obj) do
+        { 1 => "value" }
+      end
+
+      let(:expected) do
+        { "1" => "value" }
+      end
+
+      it "properly converts to bson" do
+        expect(BSON::Document.from_bson(BSON::ByteBuffer.new(obj.to_bson.to_s))).to eq(expected)
+      end
+    end
+
     context "when the hash is embedded" do
 
       let(:obj) do

--- a/spec/bson/integer_spec.rb
+++ b/spec/bson/integer_spec.rb
@@ -62,10 +62,10 @@ describe Integer do
   describe "#to_bson_key" do
 
     let(:obj)  { Integer::MAX_32BIT - 1 }
-    let(:encoded) { obj.to_s + BSON::NULL_BYTE }
+    let(:encoded) { obj.to_s }
 
-    it "returns the encoded string" do
-      expect(obj.to_bson_key.to_s).to eq(encoded)
+    it "returns the key as a string" do
+      expect(obj.to_bson_key).to eq(encoded)
     end
   end
 end


### PR DESCRIPTION
String and Symbol return a String, so Integer should as well.