### PR TITLE
Serialize symbols to string types

### DIFF
--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -74,7 +74,7 @@ module BSON
       # @since 2.0.0
       def from_bson(buffer)
         hash = Document.allocate
-        buffer.get_int32 # Throw away the size - todo: just move read position?
+        buffer.get_int32 # Throw away the size.
         while (type = buffer.get_byte) != NULL_BYTE
           field = buffer.get_cstring
           hash.store(field, BSON::Registry.get(type).from_bson(buffer))

--- a/lib/bson/integer.rb
+++ b/lib/bson/integer.rb
@@ -161,7 +161,6 @@ module BSON
     def out_of_range!
       raise RangeError.new("#{self} is not a valid 8 byte integer value.")
     end
-
   end
 
   # Enrich the core Integer class with this module.

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -30,6 +30,22 @@ module BSON
     # @since 2.0.0
     BSON_TYPE = 14.chr.force_encoding(BINARY).freeze
 
+    # Symbols are serialized as strings as symbols are now removed from the
+    # BSON specification. Therefore the bson_type when serializing must be a
+    # string.
+    #
+    # @example Get the BSON type for the symbol.
+    #   :test.bson_type
+    #
+    # @return [ String ] The single byte BSON type.
+    #
+    # @see http://bsonspec.org/#/specification
+    #
+    # @since 4.0.0
+    def bson_type
+      String::BSON_TYPE
+    end
+
     # Get the symbol as encoded BSON.
     #
     # @example Get the symbol as encoded BSON.
@@ -89,7 +105,7 @@ module BSON
     # Register this type when the module is loaded.
     #
     # @since 2.0.0
-    Registry.register(BSON_TYPE, ::Symbol)
+    Registry::MAPPINGS.store(BSON_TYPE, ::Symbol)
   end
 
   # Enrich the core Symbol class with this module.

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -840,15 +840,6 @@ describe BSON::Document do
       end
     end
 
-    context "when the symbols are utf-8" do
-
-      let(:document) do
-        described_class["type", "gültig".to_sym]
-      end
-
-      it_behaves_like "a document able to handle utf-8"
-    end
-
     context "when utf-8 string values are in an array" do
 
       let(:document) do

--- a/spec/bson/symbol_spec.rb
+++ b/spec/bson/symbol_spec.rb
@@ -16,16 +16,22 @@ require "spec_helper"
 
 describe Symbol do
 
+  describe "#bson_type" do
+
+    it "returns the type for a string" do
+      expect(:type.bson_type).to eq("type".bson_type)
+    end
+  end
+
   describe "#to_bson/#from_bson" do
 
-    let(:type) { 14.chr }
+    let(:type) { 2.chr }
     let(:obj)  { :test }
     let(:bson) { "#{5.to_bson.to_s}test#{BSON::NULL_BYTE}" }
 
     it_behaves_like "a bson element"
     it_behaves_like "a serializable bson element"
     it_behaves_like "a deserializable bson element"
-
   end
 
   describe "#to_bson_key" do


### PR DESCRIPTION
We previously serialized symbols as strings, since they were deprecated, but still set the type byte in the serialized BSON to `0x0E`, which was the deprecated symbol type. This pull changes the serialized type to be `0x02`, which is string, while still maintaining the ability to *deserialize* symbols when the type in the BSON being decoded is `0x0E`.