### PR TITLE
Initialize ObjectId counter to a random value

### DIFF
--- a/ext/bson/native.c
+++ b/ext/bson/native.c
@@ -92,7 +92,7 @@ static char rb_bson_machine_id_hash[HOST_NAME_HASH_MAX];
 /**
  * The counter for incrementing object ids.
  */
-static unsigned int rb_bson_object_id_counter = 0;
+static unsigned int rb_bson_object_id_counter;
 
 /**
  * Initialize the native extension.
@@ -136,6 +136,9 @@ void Init_native()
   gethostname(rb_bson_machine_id, sizeof(rb_bson_machine_id));
   rb_bson_machine_id[255] = '\0';
   rb_bson_generate_machine_id(rb_md5_class, rb_bson_machine_id);
+
+  // Set the object id counter to a random number
+  rb_bson_object_id_counter = FIX2INT(rb_funcall(rb_mKernel, rb_intern("rand"), 1, INT2FIX(0x1000000)));
 }
 
 void rb_bson_generate_machine_id(VALUE rb_md5_class, char *rb_bson_machine_id)

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -331,7 +331,7 @@ module BSON
       #
       # @since 2.0.0
       def initialize
-        @counter = 0
+        @counter = rand(0x1000000)
         @machine_id = Digest::MD5.digest(Socket.gethostname).unpack("N")[0]
         @mutex = Mutex.new
       end


### PR DESCRIPTION
The [ObjectId spec](https://docs.mongodb.org/v3.0/reference/object-id/) says the counter should be initialized to a random value. Initialize the counter using Ruby's `Kernel#rand` in both the native extension and the pure Ruby implementation.