### PR TITLE
RUBY-1091: Fix big endian object id generation.

### DIFF
--- a/ext/bson/native.c
+++ b/ext/bson/native.c
@@ -93,7 +93,7 @@ static char rb_bson_machine_id_hash[HOST_NAME_HASH_MAX];
 /**
  * The counter for incrementing object ids.
  */
-static unsigned int rb_bson_object_id_counter;
+static uint32_t rb_bson_object_id_counter;
 
 /**
  * Initialize the native extension.

--- a/ext/bson/native.c
+++ b/ext/bson/native.c
@@ -536,28 +536,21 @@ VALUE rb_bson_object_id_generator_next(int argc, VALUE* args, VALUE self)
   char bytes[12];
   uint32_t t;
   uint32_t c;
-  unsigned short pid = htons(getpid());
+  uint16_t pid = BSON_UINT16_TO_BE(getpid());
 
   if (argc == 0 || (argc == 1 && *args == Qnil)) {
-    t = htonl((int) time(NULL));
+    t = BSON_UINT32_TO_BE((int) time(NULL));
   }
   else {
-    t = htonl(NUM2ULONG(rb_funcall(*args, rb_intern("to_i"), 0)));
+    t = BSON_UINT32_TO_BE(NUM2ULONG(rb_funcall(*args, rb_intern("to_i"), 0)));
   }
 
-  c = htonl(rb_bson_object_id_counter << 8);
+  c = BSON_UINT32_TO_BE(rb_bson_object_id_counter << 8);
 
-# if BSON_BYTE_ORDER == BSON_LITTLE_ENDIAN
   memcpy(&bytes, &t, 4);
   memcpy(&bytes[4], rb_bson_machine_id_hash, 3);
   memcpy(&bytes[7], &pid, 2);
   memcpy(&bytes[9], (unsigned char*) &c, 3);
-#elif BSON_BYTE_ORDER == BSON_BIG_ENDIAN
-  memcpy(&bytes, ((unsigned char*) &t) + 4, 4);
-  memcpy(&bytes[4], rb_bson_machine_id_hash, 3);
-  memcpy(&bytes[7], &pid, 2);
-  memcpy(&bytes[9], ((unsigned char*) &c) + 4, 3);
-#endif
   rb_bson_object_id_counter++;
   return rb_str_new(bytes, 12);
 }

--- a/spec/bson/object_id_spec.rb
+++ b/spec/bson/object_id_spec.rb
@@ -383,6 +383,15 @@ describe BSON::ObjectId do
     end
   end
 
+  describe "#initialize" do
+
+    it "does not generate duplicate ids" do
+      100000.times do
+        expect(BSON::ObjectId.new).to_not eq(BSON::ObjectId.new)
+      end
+    end
+  end
+
   describe "#inspect" do
 
     let(:object_id) do


### PR DESCRIPTION
Fix leverages the endian macros - was slated to do this anyways after the `ByteBuffer` rewrite.

Added a spec that generates 100k ids in succession and asserts there were no duplicates. Passes locally for me on OSX and also remotely on our Solaris 11.2 SPARC box.