### PR TITLE
Prevent warning from redefinition of :respond_to?

### DIFF
--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -152,8 +152,8 @@ module BSON
       # @param [ String] method The name of a method.
       #
       # @since 3.1.0
-      def respond_to?(method)
-        compile.respond_to?(method) || super
+      def respond_to?(method, include_private = false)
+        compile.respond_to?(method, include_private = false) || super
       end
 
       private


### PR DESCRIPTION
The BSON::Regexp::Raw#respond_to? method has a different signature than in [Rails](https://github.com/rails/rails/blob/a63760cea7d858984f83549019297221f18ed574/actionpack/lib/action_dispatch/testing/integration.rb#L385). This results in warnings like:

```
/home/reed/.gem/ruby/2.3.0/gems/mongoid-5.1.1/lib/mongoid/matchable/default.rb:35: warning: BSON::Regexp::Raw#respond_to?(:to_str) is old fashion which takes only one parameter                                                                                                                                       
/home/reed/.gem/ruby/2.3.0/gems/bson-4.0.2/lib/bson/regexp.rb:155: warning: respond_to? is defined here
```