### PR TITLE
RUBY-1092 Validate keys of hashes in an array

### DIFF
--- a/lib/bson/array.rb
+++ b/lib/bson/array.rb
@@ -40,13 +40,13 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       position = buffer.length
       buffer.put_int32(0)
       each_with_index do |value, index|
         buffer.put_byte(value.bson_type)
         buffer.put_cstring(index.to_s)
-        value.to_bson(buffer)
+        value.to_bson(buffer, validating_keys)
       end
       buffer.put_byte(NULL_BYTE)
       buffer.replace_int32(position, buffer.length - position)

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -129,7 +129,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       position = buffer.length
       buffer.put_int32(0)
       buffer.put_byte(SUBTYPES[type])

--- a/lib/bson/code.rb
+++ b/lib/bson/code.rb
@@ -81,7 +81,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_string(javascript) # @todo: was formerly to_bson_string
     end
 

--- a/lib/bson/code_with_scope.rb
+++ b/lib/bson/code_with_scope.rb
@@ -87,7 +87,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       position = buffer.length
       buffer.put_int32(0)
       buffer.put_string(javascript)

--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -34,7 +34,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.1.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       ::Time.utc(year, month, day).to_bson(buffer)
     end
 

--- a/lib/bson/date_time.rb
+++ b/lib/bson/date_time.rb
@@ -34,7 +34,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.1.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       to_time.to_bson(buffer)
     end
   end

--- a/lib/bson/false_class.rb
+++ b/lib/bson/false_class.rb
@@ -49,7 +49,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_byte(FALSE_BYTE)
     end
   end

--- a/lib/bson/float.rb
+++ b/lib/bson/float.rb
@@ -42,7 +42,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_double(self)
     end
 

--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -43,7 +43,7 @@ module BSON
       each do |field, value|
         buffer.put_byte(value.bson_type)
         buffer.put_cstring(field.to_bson_key(validating_keys))
-        value.to_bson(buffer)
+        value.to_bson(buffer, validating_keys)
       end
       buffer.put_byte(NULL_BYTE)
       buffer.replace_int32(position, buffer.length - position)

--- a/lib/bson/integer.rb
+++ b/lib/bson/integer.rb
@@ -103,7 +103,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       if bson_int32?
         buffer.put_int32(self)
       elsif bson_int64?

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -168,7 +168,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_bytes(generate_data)
     end
 

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -84,7 +84,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_cstring(source)
       buffer.put_cstring(bson_options)
     end

--- a/lib/bson/specialized.rb
+++ b/lib/bson/specialized.rb
@@ -45,7 +45,7 @@ module BSON
     # @return [ String ] An empty string.
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer
     end
 

--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -45,7 +45,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_string(self)
     end
 

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -56,7 +56,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       to_s.to_bson(buffer)
     end
 

--- a/lib/bson/time.rb
+++ b/lib/bson/time.rb
@@ -37,7 +37,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_int64((to_i * 1000) + (usec / 1000))
     end
 

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -87,7 +87,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_int32(increment)
       buffer.put_int32(seconds)
     end

--- a/lib/bson/true_class.rb
+++ b/lib/bson/true_class.rb
@@ -49,7 +49,7 @@ module BSON
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.0.0
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_byte(TRUE_BYTE)
     end
   end

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -75,6 +75,19 @@ describe Hash do
               obj.to_bson
             }.to raise_error(BSON::String::IllegalKey)
           end
+
+          context "when the hash contains an array of documents containing invalid keys" do
+
+            let(:obj) do
+              { "array" =>  [{ "$testing" => "value" }] }
+            end
+
+            it "raises an error" do
+              expect {
+                obj.to_bson
+              }.to raise_error(BSON::String::IllegalKey)
+            end
+          end
         end
 
         context "when validating locally" do
@@ -83,6 +96,19 @@ describe Hash do
             expect {
               obj.to_bson(BSON::ByteBuffer.new, true)
             }.to raise_error(BSON::String::IllegalKey)
+          end
+
+          context "when the hash contains an array of documents containing invalid keys" do
+
+            let(:obj) do
+              { "array" =>  [{ "$testing" => "value" }] }
+            end
+
+            it "raises an error" do
+              expect {
+                obj.to_bson(BSON::ByteBuffer.new, true)
+              }.to raise_error(BSON::String::IllegalKey)
+            end
           end
         end
       end
@@ -96,6 +122,22 @@ describe Hash do
 
         it "serializes the hash" do
           expect(obj.to_bson.to_s).to eq(bson)
+        end
+
+        context "when the hash contains an array of documents containing invalid keys" do
+
+          let(:obj) do
+            { "array" =>  [{ "$testing" => "value" }] }
+          end
+
+          let(:bson) do
+            "#{45.to_bson.to_s}#{Array::BSON_TYPE}array#{BSON::NULL_BYTE}" +
+              "#{[{ "$testing" => "value" }].to_bson.to_s}#{BSON::NULL_BYTE}"
+          end
+
+          it "serializes the hash" do
+            expect(obj.to_bson.to_s).to eq(bson)
+          end
         end
       end
     end


### PR DESCRIPTION
I noticed that we needed this set of changes when testing key validation with the driver.

The driver would try to serialize a write command like the following:
```ruby
{:insert=>"test", :documents=>[{"$testing"=>"value", :_id=>BSON::ObjectId('...')}], :ordered=>true, :writeConcern=>{:w=>1}}
```

The keys of the documents would not be validated because the top-level type is an Array. This pull request also applies key validation on hashes that are members of an Array so that we can actually use it from the driver.