### PR TITLE
Renamed extension from native to bson_native

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ if jruby?
 else
   require "rake/extensiontask"
   Rake::ExtensionTask.new do |ext|
-    ext.name = "native"
+    ext.name = "bson_native"
     ext.ext_dir = "ext/bson"
     ext.lib_dir = "lib"
   end
@@ -64,8 +64,8 @@ end
 task :clean_all => :clean do
   begin
     Dir.chdir(Pathname(__FILE__).dirname + "lib") do
-      `rm native.#{extension}`
-      `rm native.o`
+      `rm bson_native.#{extension}`
+      `rm bson_native.o`
       `rm bson-ruby.jar`
     end
   rescue Exception => e

--- a/ext/bson/bson_native.c
+++ b/ext/bson/bson_native.c
@@ -96,9 +96,9 @@ static char rb_bson_machine_id_hash[HOST_NAME_HASH_MAX];
 static uint32_t rb_bson_object_id_counter;
 
 /**
- * Initialize the native extension.
+ * Initialize the bson_native extension.
  */
-void Init_native()
+void Init_bson_native()
 {
   char rb_bson_machine_id[256];
 

--- a/ext/bson/extconf.rb
+++ b/ext/bson/extconf.rb
@@ -1,3 +1,3 @@
 require "mkmf"
 $CFLAGS << " -Wall -g -std=c99"
-create_makefile("native")
+create_makefile("bson_native")

--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -98,7 +98,7 @@ begin
     require "bson-ruby.jar"
     org.bson.NativeService.new.basicLoad(JRuby.runtime)
   else
-    require "native"
+    require "bson_native"
   end
 rescue LoadError
   $stderr.puts("BSON is using the pure Ruby implementation.")


### PR DESCRIPTION
Current extension name "native" is too loud in global namespace.
So I propose to add prefix "bson_" and change it to "bson_native".