### PR TITLE
Avoid ruby warnings

### DIFF
--- a/lib/bson/config.rb
+++ b/lib/bson/config.rb
@@ -45,7 +45,7 @@ module BSON
     #
     # @since 4.1.0
     def validating_keys?
-      !!@validating_keys
+      !!(@validating_keys||=nil)
     end
   end
 end


### PR DESCRIPTION
Removes this from the logs => warning: instance variable @validating_keys not initialized