### PR TITLE
[for 4.2.0] Add BSON::ObjectId#to_time as alias to #generation_time

### DIFF
--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -102,6 +102,7 @@ module BSON
     def generation_time
       ::Time.at(generate_data.unpack("N")[0]).utc
     end
+    alias :to_time :generation_time
 
     # Get the hash value for the object id.
     #


### PR DESCRIPTION
Goes well with `#from_time` and `#to_s`