### PR TITLE
RUBY-1098 Support a String passed to Decimal128#new

### DIFF
--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -239,6 +239,8 @@ module BSON
 
     # Raised when trying to create a Decimal128 from an object that is neither a String nor a BigDecimal.
     #
+    # @api private
+    #
     # @since 4.2.0
     class InvalidArgument < ArgumentError
 
@@ -263,6 +265,8 @@ module BSON
     # Raised when trying to create a Decimal128 from a string with
     #   an invalid format.
     #
+    # @api private
+    #
     # @since 4.2.0
     class InvalidString < RuntimeError
 
@@ -285,6 +289,8 @@ module BSON
     end
 
     # Raised when the exponent or significand provided is outside the valid range.
+    #
+    # @api private
     #
     # @since 4.2.0
     class InvalidRange < RuntimeError

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -54,11 +54,6 @@ module BSON
     # @since 4.2.0
     NATIVE_TYPE = BigDecimal.freeze
 
-    # The error message if neither a String nor a BigDecimal are passed to #new.
-    #
-    # @since 4.2.0
-    INVALID_TYPE_MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'.freeze
-
     # Get the Decimal128 as JSON hash data.
     #
     # @example Get the Decimal128 as a JSON hash.
@@ -105,7 +100,7 @@ module BSON
       elsif object.is_a?(BigDecimal)
         set_bits(*Builder::FromBigDecimal.new(object).bits)
       else
-        raise ArgumentError.new(INVALID_TYPE_MESSAGE)
+        raise InvalidArgument.new
       end
     end
 
@@ -239,6 +234,29 @@ module BSON
         decimal = allocate
         decimal.send(:set_bits, low, high)
         decimal
+      end
+    end
+
+    # Raised when trying to create a Decimal128 from an object that is neither a String nor a BigDecimal.
+    #
+    # @since 4.2.0
+    class InvalidArgument < ArgumentError
+
+      # The custom error message for this error.
+      #
+      # @since 4.2.0
+      MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'.freeze
+
+      # Get the custom error message for the exception.
+      #
+      # @example Get the message.
+      #   error.message
+      #
+      # @return [ String ] The error message.
+      #
+      # @since 4.2.0
+      def message
+        MESSAGE
       end
     end
 

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -54,6 +54,11 @@ module BSON
     # @since 4.2.0
     NATIVE_TYPE = BigDecimal.freeze
 
+    # The error message if neither a String nor a BigDecimal are passed to #new.
+    #
+    # @since 4.2.0
+    INVALID_TYPE_MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'
+
     # Get the Decimal128 as JSON hash data.
     #
     # @example Get the Decimal128 as a JSON hash.
@@ -88,15 +93,20 @@ module BSON
     # @example Create a Decimal128 from a BigDecimal.
     #   Decimal128.new(big_decimal)
     #
-    # @param [ BigDecimal ] big_decimal The BigDecimal to use for
+    # @param [ String, BigDecimal ] object The BigDecimal or String to use for
     #   instantiating a Decimal128.
     #
     # @raise [ InvalidBigDecimal ] Raise error unless object argument is a BigDecimal.
     #
     # @since 4.2.0
-    def initialize(big_decimal)
-      raise InvalidBigDecimal.new unless big_decimal.is_a?(BigDecimal)
-      set_bits(*Builder::FromBigDecimal.new(big_decimal).bits)
+    def initialize(object)
+      if object.is_a?(String)
+        set_bits(*Builder::FromString.new(object).bits)
+      elsif object.is_a?(BigDecimal)
+        set_bits(*Builder::FromBigDecimal.new(object).bits)
+      else
+        raise ArgumentError.new(INVALID_TYPE_MESSAGE)
+      end
     end
 
     # Get the decimal128 as its raw BSON data.
@@ -231,11 +241,6 @@ module BSON
         decimal
       end
     end
-
-    # Raised when a Decimal128 is instantiated with a non-BigDecimal object.
-    #
-    # @since 4.2.0
-    class InvalidBigDecimal < RuntimeError; end
 
     # Raised when trying to create a Decimal128 from a string with
     #   an invalid format.

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -57,7 +57,7 @@ module BSON
     # The error message if neither a String nor a BigDecimal are passed to #new.
     #
     # @since 4.2.0
-    INVALID_TYPE_MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'
+    INVALID_TYPE_MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'.freeze
 
     # Get the Decimal128 as JSON hash data.
     #

--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -307,10 +307,11 @@ module BSON
 
         def to_bits
           sign, significand_str, base, exp = @big_decimal.split
-          exponent = exp - significand_str.length
+          exponent = @big_decimal.zero? ? 0 : exp - significand_str.length
+          is_negative = (sign == BigDecimal::SIGN_NEGATIVE_FINITE || sign == BigDecimal::SIGN_NEGATIVE_ZERO)
           Builder.parts_to_bits(significand_str.to_i,
                                 exponent,
-                                @big_decimal.sign == BigDecimal::SIGN_NEGATIVE_FINITE)
+                                is_negative)
         end
 
         def special?

--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -18,6 +18,8 @@ module BSON
     # Helper module for parsing String, Integer, Float, BigDecimal, and Decimal128
     # objects into other objects.
     #
+    # @api private
+    #
     # @since 4.2.0
     module Builder
 
@@ -96,6 +98,8 @@ module BSON
       end
 
       # Helper class for parsing a String into Decimal128 high and low bits.
+      #
+      # @api private
       #
       # @since 4.2.0
       class FromString
@@ -259,6 +263,8 @@ module BSON
 
       # Helper class for parsing a BigDecimal into Decimal128 high and low bits.
       #
+      # @api private
+      #
       # @since 4.2.0
       class FromBigDecimal
 
@@ -320,6 +326,8 @@ module BSON
       end
 
       # Helper class for getting a String representation of a Decimal128 object.
+      #
+      # @api private
       #
       # @since 4.2.0
       class ToString

--- a/spec/bson/decimal128_spec.rb
+++ b/spec/bson/decimal128_spec.rb
@@ -26,6 +26,15 @@ describe BSON::Decimal128 do
 
   describe '#initialize' do
 
+    context 'when the argument is neither a BigDecimal or String' do
+
+      it 'raises an ArgumentError' do
+        expect {
+          described_class.new(:invalid)
+        }.to raise_exception(ArgumentError)
+      end
+    end
+
     shared_examples_for 'an initialized BSON::Decimal128' do
 
       let(:decimal128) do
@@ -53,68 +62,168 @@ describe BSON::Decimal128 do
       end
 
       it 'deserializes to the correct bits' do
-        expect(from_bson.instance_variable_get(:@high)).to eq(high_bits)
-        expect(from_bson.instance_variable_get(:@low)).to eq(low_bits)
-      end
-    end
-
-    context 'when the value is not a valid big decimal or String' do
-
-      it 'raises an exception' do
-        expect {
-          described_class.new(:invalid)
-        }.to raise_exception(described_class::InvalidBigDecimal)
+        expect(from_bson.instance_variable_get(:@high)).to eq(expected_high_bits)
+        expect(from_bson.instance_variable_get(:@low)).to eq(expected_low_bits)
       end
     end
 
     context 'when the object represents positive infinity' do
 
       let(:expected_high_bits) { 0x7800000000000000 }
-      let(:expected_low_bits) { 0 }
+      let(:expected_low_bits) { 0x0000000000000000 }
 
-      let(:argument) { BigDecimal.new("Infinity") }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new("Infinity") }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "Infinity" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents negative infinity' do
 
       let(:expected_high_bits) { 0xf800000000000000 }
-      let(:expected_low_bits) { 0 }
+      let(:expected_low_bits) { 0x0000000000000000 }
 
-      let(:argument) { BigDecimal.new("-Infinity") }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new("-Infinity") }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-Infinity" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents NaN' do
 
       let(:expected_high_bits) { 0x7c00000000000000 }
-      let(:expected_low_bits) { 0 }
+      let(:expected_low_bits) { 0x0000000000000000 }
 
-      let(:argument) { BigDecimal.new("NaN") }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new("NaN") }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "NaN" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+    end
+
+    context 'when the object represents -NaN' do
+
+      let(:expected_high_bits) { 0xfc00000000000000 }
+      let(:expected_low_bits) { 0x0000000000000000 }
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-NaN" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+    end
+
+    context 'when the object represents SNaN' do
+
+      let(:expected_high_bits) { 0x7e00000000000000 }
+      let(:expected_low_bits) { 0x0000000000000000 }
+
+      context 'when a String is passed' do
+
+        let(:argument) { "SNaN" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+    end
+
+    context 'when the object represents -SNaN' do
+
+      let(:expected_high_bits) { 0xfe00000000000000 }
+      let(:expected_low_bits) { 0x0000000000000000 }
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-SNaN" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+    end
+
+    context 'when the object represents -0' do
+
+      let(:expected_high_bits) { 0xb040000000000000 }
+      let(:expected_low_bits) { 0x0000000000000000 }
+
+      context 'when a BigDecimal is passed' do
+
+        let(:argument) { BigDecimal.new("-0") }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-0" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents a positive integer' do
 
       let(:expected_high_bits) { 0x3040000000000000 }
-      let(:expected_low_bits) { 12 }
+      let(:expected_low_bits) { 0x000000000000000c }
 
-      let(:argument) { BigDecimal.new(12) }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new(12) }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "12" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents a negative integer' do
 
       let(:expected_high_bits) { 0xb040000000000000 }
-      let(:expected_low_bits) { 12 }
+      let(:expected_low_bits) { 0x000000000000000c }
 
-      let(:argument) { BigDecimal.new(-12) }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new(-12) }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-12" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents a positive float' do
@@ -122,9 +231,19 @@ describe BSON::Decimal128 do
       let(:expected_high_bits) { 0x3036000000000000 }
       let(:expected_low_bits) { 0x0000000000003039 }
 
-      let(:argument) { BigDecimal.new(0.12345, 5) }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new(0.12345, 5) }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "0.12345" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents a negative float' do
@@ -132,9 +251,19 @@ describe BSON::Decimal128 do
       let(:expected_high_bits) { 0xb036000000000000 }
       let(:expected_low_bits) { 0x0000000000003039 }
 
-      let(:argument) { BigDecimal.new(-0.12345, 5) }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new(-0.12345, 5) }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-0.12345" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents a large positive integer' do
@@ -142,9 +271,19 @@ describe BSON::Decimal128 do
       let(:expected_high_bits) { 0x30403cde6fff9732 }
       let(:expected_low_bits) { 0xde825cd07e96aff2 }
 
-      let(:argument) { BigDecimal.new(1234567890123456789012345678901234) }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new(1234567890123456789012345678901234) }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "1234567890123456789012345678901234" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
 
     context 'when the object represents a large negative integer' do
@@ -152,9 +291,19 @@ describe BSON::Decimal128 do
       let(:expected_high_bits) { 0xb0403cde6fff9732 }
       let(:expected_low_bits) { 0xde825cd07e96aff2 }
 
-      let(:argument) { BigDecimal.new(-1234567890123456789012345678901234) }
+      context 'when a BigDecimal is passed' do
 
-      it_behaves_like 'an initialized BSON::Decimal128'
+        let(:argument) { BigDecimal.new(-1234567890123456789012345678901234) }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
+
+      context 'when a String is passed' do
+
+        let(:argument) { "-1234567890123456789012345678901234" }
+
+        it_behaves_like 'an initialized BSON::Decimal128'
+      end
     end
   end
 
@@ -228,7 +377,7 @@ describe BSON::Decimal128 do
         let(:string) { 'NaN' }
 
         let(:expected_high_bits) { 0x7c00000000000000 }
-        let(:expected_low_bits) { 0 }
+        let(:expected_low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 initialized from a string'
       end
@@ -238,7 +387,27 @@ describe BSON::Decimal128 do
         let(:string) { '-NaN' }
 
         let(:expected_high_bits) { 0xfc00000000000000 }
-        let(:expected_low_bits) { 0 }
+        let(:expected_low_bits) { 0x0000000000000000 }
+
+        it_behaves_like 'a decimal128 initialized from a string'
+      end
+
+      context "when the string is 'SNaN'" do
+
+        let(:string) { 'SNaN' }
+
+        let(:expected_high_bits) { 0x7e00000000000000 }
+        let(:expected_low_bits) { 0x0000000000000000 }
+
+        it_behaves_like 'a decimal128 initialized from a string'
+      end
+
+      context "when the string is '-SNaN'" do
+
+        let(:string) { '-SNaN' }
+
+        let(:expected_high_bits) { 0xfe00000000000000 }
+        let(:expected_low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 initialized from a string'
       end
@@ -250,7 +419,7 @@ describe BSON::Decimal128 do
         let(:expected_exponent) { nil }
         let(:expected_significand) { nil }
         let(:expected_high_bits) { 0x7800000000000000 }
-        let(:expected_low_bits) { 0 }
+        let(:expected_low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 initialized from a string'
       end
@@ -262,7 +431,7 @@ describe BSON::Decimal128 do
         let(:expected_exponent) { nil }
         let(:expected_significand) { nil }
         let(:expected_high_bits) { 0xf800000000000000 }
-        let(:expected_low_bits) { 0 }
+        let(:expected_low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 initialized from a string'
       end
@@ -794,7 +963,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { 'NaN' }
         let(:high_bits) { 0xfc00000000000000 }
-        let(:low_bits) { 0x0 }
+        let(:low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -803,16 +972,16 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { 'NaN' }
         let(:high_bits) { 0x7e00000000000000 }
-        let(:low_bits) { 0x0 }
+        let(:low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
 
-      context 'when the decimal is negative SNaN' do
+      context 'when the decimal is -SNaN' do
 
         let(:expected_string) { 'NaN' }
         let(:high_bits) { 0xfe00000000000000 }
-        let(:low_bits) { 0x0 }
+        let(:low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -821,7 +990,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { 'NaN' }
         let(:high_bits) { 0x7e00000000000000 }
-        let(:low_bits) { 0x8 }
+        let(:low_bits) { 0x0000000000000008 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -830,7 +999,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { 'Infinity' }
         let(:high_bits) { 0x7800000000000000 }
-        let(:low_bits) { 0x8 }
+        let(:low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -839,7 +1008,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '-Infinity' }
         let(:high_bits) { 0xf800000000000000 }
-        let(:low_bits) { 0x8 }
+        let(:low_bits) { 0x0000000000000000 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -851,7 +1020,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '1' }
         let(:high_bits) { 0x3040000000000000 }
-        let(:low_bits) { 0x1 }
+        let(:low_bits) { 0x0000000000000001 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -860,7 +1029,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '-1' }
         let(:high_bits) { 0xb040000000000000 }
-        let(:low_bits) { 0x1 }
+        let(:low_bits) { 0x0000000000000001 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -869,7 +1038,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '20' }
         let(:high_bits) { 0x3040000000000000 }
-        let(:low_bits) { 0x14 }
+        let(:low_bits) { 0x0000000000000014 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -878,7 +1047,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '-20' }
         let(:high_bits) { 0xb040000000000000 }
-        let(:low_bits) { 0x14 }
+        let(:low_bits) { 0x0000000000000014 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -926,7 +1095,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '0.1' }
         let(:high_bits) { 0x303e000000000000 }
-        let(:low_bits) { 0x1 }
+        let(:low_bits) { 0x0000000000000001 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -935,7 +1104,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '-0.1' }
         let(:high_bits) { 0xb03e000000000000 }
-        let(:low_bits) { 0x1 }
+        let(:low_bits) { 0x0000000000000001 }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -944,7 +1113,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '0.123' }
         let(:high_bits) { 0x303a000000000000 }
-        let(:low_bits) { 0x7b }
+        let(:low_bits) { 0x000000000000007b }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -953,7 +1122,7 @@ describe BSON::Decimal128 do
 
         let(:expected_string) { '-0.123' }
         let(:high_bits) { 0xb03a000000000000 }
-        let(:low_bits) { 0x7b }
+        let(:low_bits) { 0x000000000000007b }
 
         it_behaves_like 'a decimal128 printed to a string'
       end
@@ -963,7 +1132,7 @@ describe BSON::Decimal128 do
 
       let(:expected_string) { '0.001234' }
       let(:high_bits) { 0x3034000000000000 }
-      let(:low_bits) { 0x4d2 }
+      let(:low_bits) { 0x00000000000004d2 }
 
       it_behaves_like 'a decimal128 printed to a string'
     end
@@ -972,7 +1141,7 @@ describe BSON::Decimal128 do
 
       let(:expected_string) { '2.000' }
       let(:high_bits) { 0x303a000000000000 }
-      let(:low_bits) { 0x7d0 }
+      let(:low_bits) { 0x00000000000007d0 }
 
       it_behaves_like 'a decimal128 printed to a string'
     end

--- a/spec/bson/driver_bson_spec.rb
+++ b/spec/bson/driver_bson_spec.rb
@@ -29,15 +29,15 @@ describe 'Driver common bson tests' do
           end
 
           it 'parses the string value to the same value as the decoded document', if: test.from_string? do
-            expect(BSON::Decimal128.from_string(test.string)).to eq(test.object)
+            expect(BSON::Decimal128.new(test.string)).to eq(test.object)
           end
 
           it 'parses the #to_s (match_string) value to the same value as the decoded document', if: test.match_string do
-            expect(BSON::Decimal128.from_string(test.match_string)).to eq(test.object)
+            expect(BSON::Decimal128.new(test.match_string)).to eq(test.object)
           end
 
           it 'creates the correct object from a non canonical string and then prints to the correct string', if: test.match_string do
-            expect(BSON::Decimal128.from_string(test.string).to_s).to eq(test.match_string)
+            expect(BSON::Decimal128.new(test.string).to_s).to eq(test.match_string)
           end
 
           it 'can be converted to a native type' do


### PR DESCRIPTION
When looking into how Mongoid would handle converting BigDecimal objects previously "serialized" as Strings in the db to Decimal128 objects, I realized it would be simpler to handle Strings in the Decimal128 constructor. Otherwise, the method Decimal128#from_string would have to be used explicitly.