### PR TITLE
Made timestamp as_json match mongo specifications

### DIFF
--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -61,7 +61,7 @@ module BSON
     #
     # @since 2.0.0
     def as_json(*args)
-      { "t" => seconds, "i" => increment }
+      { "$timestamp" => { "t" => seconds, "i" => increment } }
     end
 
     # Instantiate the new timestamp.

--- a/spec/bson/timestamp_spec.rb
+++ b/spec/bson/timestamp_spec.rb
@@ -55,7 +55,7 @@ describe BSON::Timestamp do
     end
 
     it "returns the binary data plus type" do
-      expect(object.as_json).to eq({ "t" => 10, "i" => 50 })
+      expect(object.as_json).to eq({"$timestamp" => { "t" => 10, "i" => 50 } })
     end
 
     it_behaves_like "a JSON serializable object"


### PR DESCRIPTION
According to mongo specifications timestamp.to_json should be in the form of { "$timestamp": { "t": <t>, "i": <i> } }
source:
https://docs.mongodb.com/manual/reference/mongodb-extended-json/