### PR TITLE
Improve Ruby Symbol handling

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -492,6 +492,9 @@ axes:
       - id: "rhel55-32"
         display_name: "RHEL 5.5 32-bit"
         run_on: rhel55-32
+      - id: "ubuntu1604-arm64-small"
+        display_name: "Ubuntu 16.04 ARM64"
+        run_on: ubuntu1604-arm64-small
   - id: "all-rubies"
     display_name: Ruby Version
     values:

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -489,6 +489,9 @@ axes:
       - id: "rhelpower"
         display_name: "RHEL 7.1 PowerPC"
         run_on: rhel71-power8-test
+      - id: "rhel55-32"
+        display_name: "RHEL 5.5 32-bit"
+        run_on: rhel55-32
   - id: "all-rubies"
     display_name: Ruby Version
     values:
@@ -496,10 +499,10 @@ axes:
         display_name: ruby-1.9
         variables:
            RVM_RUBY: "ruby-1.9"
-      - id: "ruby-2.0"
-        display_name: ruby-2.0
+      - id: "ruby-2.2"
+        display_name: ruby-2.2
         variables:
-           RVM_RUBY: "ruby-2.0"
+           RVM_RUBY: "ruby-2.2"
       - id: "ruby-2.3"
         display_name: ruby-2.3
         variables:
@@ -527,10 +530,6 @@ axes:
         display_name: ruby-2.4.1
         variables:
            RVM_RUBY: "ruby-2.4.1"
-      - id: "jruby-9.1"
-        display_name: jruby-9.1
-        variables:
-           RVM_RUBY: "jruby-9.1"
 
 buildvariants:
 - matrix_name: "tests-all-rubies-all-os"
@@ -540,8 +539,6 @@ buildvariants:
      - name: "test"
 - matrix_name: "tests-special-os"
   matrix_spec: { latest-stable-rubies: "*", special-os: "*" }
-  exclude_spec: { latest-stable-rubies: "jruby-1.7", special-os: "*" }
-  exclude_spec: { latest-stable-rubies: "jruby-9.1", special-os: "*" }
   display_name: "${latest-stable-rubies}, ${special-os}"
   tasks:
      - name: "test"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -15,9 +15,9 @@ source ~/.rvm/scripts/rvm
 export JAVACMD=/opt/java/jdk8/bin/java
 export PATH=$PATH:/opt/java/jdk8/bin
 
-#if [ "$RVM_RUBY" == "ruby-head" ]; then
+if [ "$RVM_RUBY" == "ruby-head" ]; then
   rvm reinstall $RVM_RUBY
-#fi
+fi
 
 rvm use $RVM_RUBY
 gem install bundler

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,7 +19,19 @@ if [ "$RVM_RUBY" == "ruby-head" ]; then
   rvm reinstall $RVM_RUBY
 fi
 
+# Don't errexit because this may call scripts which error
+set +o errexit
 rvm use $RVM_RUBY
+set -o errexit
+
+# Ensure we're using the right ruby
+python - <<EOH
+ruby = "${RVM_RUBY}".split("-")[0]
+version = "${RVM_RUBY}".split("-")[1]
+assert(ruby in "`ruby --version`")
+assert(version in "`ruby --version`")
+EOH
+
 gem install bundler
 
 echo "Installing all gem dependencies"

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'rspec', '~> 3.2'
   gem 'rake-compiler'
   gem 'ruby-prof', :platforms => :mri
-
+  
   if ENV['CI']
     gem 'mime-types', '1.25' # v2.0+ does not support ruby 1.8
   else

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -57,7 +57,7 @@ module BSON
     #
     # @since 2.0.0
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
-      to_s.to_bson(buffer)
+      buffer.put_symbol(self)
     end
 
     # Get the symbol as a BSON key name encoded C symbol.
@@ -71,7 +71,10 @@ module BSON
     #
     # @since 2.0.0
     def to_bson_key(validating_keys = Config.validating_keys?)
-      to_s.to_bson_key(validating_keys)
+      if validating_keys
+        raise BSON::String::IllegalKey.new(self) if BSON::String::ILLEGAL_KEY =~ self
+      end
+      self
     end
 
     # Converts the symbol to a normalized key in a BSON document.

--- a/spec/bson/symbol_spec.rb
+++ b/spec/bson/symbol_spec.rb
@@ -37,7 +37,7 @@ describe Symbol do
   describe "#to_bson_key" do
 
     let(:symbol) { :test }
-    let(:encoded) { symbol.to_s }
+    let(:encoded) { symbol }
 
     it "returns the encoded string" do
       expect(symbol.to_bson_key).to eq(encoded)
@@ -66,7 +66,7 @@ describe Symbol do
       end
 
       it "allows invalid keys" do
-        expect(symbol.to_bson_key).to eq(symbol.to_s)
+        expect(symbol.to_bson_key).to eq(symbol)
       end
     end
   end

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -34,6 +34,7 @@ import org.jruby.RubyInteger;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
+import org.jruby.RubySymbol;
 import java.math.BigInteger;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -312,7 +313,7 @@ public class ByteBuf extends RubyObject {
    */
   @JRubyMethod(name = "put_cstring")
   public ByteBuf putCString(final IRubyObject value) throws UnsupportedEncodingException {
-    String string = ((RubyString) value).asJavaString();
+    String string = value.asJavaString();
     this.writePosition += writeCharacters(string, true);
     return this;
   }
@@ -405,6 +406,39 @@ public class ByteBuf extends RubyObject {
   }
 
   /**
+   * Put a Java string onto the buffer.
+   * 
+   * @param string
+   * 
+   * @author Ben Lewis
+   * @since 2017.04.19
+   * @version 4.2.2
+   */
+  ByteBuf putJavaString(final String string) {
+    ensureBsonWrite(4);
+    this.buffer.putInt(0);
+    int length = writeCharacters(string, false);
+    this.buffer.putInt(this.buffer.position() - length - 4, length);
+    this.writePosition += (length + 4);
+    return this;
+  }
+
+  /**
+   * Put a symbol onto the buffer.
+   *
+   * @param value The UTF-8 string to write.
+   *
+   * @author Ben Lewis
+   * @since 2017.04.19
+   * @version 4.2.2
+   */
+  @JRubyMethod(name = "put_symbol")
+  public ByteBuf putSymbol(final IRubyObject value) throws UnsupportedEncodingException {
+    String string = ((RubySymbol) value).asJavaString();
+    return putJavaString(string);
+  }
+
+  /**
    * Put a UTF-8 string onto the buffer.
    *
    * @param value The UTF-8 string to write.
@@ -416,12 +450,7 @@ public class ByteBuf extends RubyObject {
   @JRubyMethod(name = "put_string")
   public ByteBuf putString(final IRubyObject value) throws UnsupportedEncodingException {
     String string = ((RubyString) value).asJavaString();
-    ensureBsonWrite(4);
-    this.buffer.putInt(0);
-    int length = writeCharacters(string, false);
-    this.buffer.putInt(this.buffer.position() - length - 4, length);
-    this.writePosition += (length + 4);
-    return this;
+    return putJavaString(string);
   }
 
   /**


### PR DESCRIPTION
By removing calls to `.to_s` but instead handling in C and Java extensions, we can expect a significant performance boost for users doing large inserts with hashes with symbol keys and pure symbol values.