### PR TITLE
Add Ruby 2.5 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 rvm:
   - 1.9.3
   - 2.4.2
+  - 2.5
   - ruby-head
   - jruby-19mode
   - jruby-9.1.12.0


### PR DESCRIPTION
Shall we add Ruby 2.5 on Travis CI, as the preview version was released?
https://www.ruby-lang.org/en/news/2017/10/10/ruby-2-5-0-preview1-released/