### PR TITLE
typos; copy fixes for ruby bson 4 tutorial

### DIFF
--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -26,7 +26,7 @@ To install the gem manually:
 
 .. code-block:: sh
 
-    gem install bson
+    gem install bson -v '~> 4.0'
 
 To install the gem with bundler, include the following in your Gemfile:
 
@@ -34,14 +34,13 @@ To install the gem with bundler, include the following in your Gemfile:
 
     gem 'bson', '~> 4.0'
 
-The BSON gem is compatible with MRI 1.9.3, 2.0.x, 2.1.x, 2.2.x, JRuby 1.7.x, and
-Rubinius 2.5.x
+The BSON gem is compatible with MRI >= 1.9.3, JRuby 1.7.x, and Rubinius 2.5.x
 
 BSON Serialization
 ------------------
 
 Getting a Ruby object's raw BSON representation is done by calling ``to_bson``
-on the Ruby object, which will return a ``ByteBuffer``. For example:
+on the Ruby object, which will return a ``BSON::ByteBuffer``. For example:
 
 .. code-block:: ruby
 
@@ -49,12 +48,12 @@ on the Ruby object, which will return a ``ByteBuffer``. For example:
   1024.to_bson
 
 Generating an object from BSON is done via calling ``from_bson`` on the class
-you wish to instantiate and passing it a ``ByteBuffer`` instance.
+you wish to instantiate and passing it a ``BSON::ByteBuffer`` instance.
 
 .. code-block:: ruby
 
   String.from_bson(byte_buffer)
-  Int32.from_bson(byte_buffer)
+  BSON::Int32.from_bson(byte_buffer)
 
 Byte Buffers
 ------------
@@ -90,14 +89,14 @@ Reading from the buffer is done via the following API:
 
   buffer.get_byte # Pulls a single byte from the buffer.
   buffer.get_bytes(value) # Pulls n number of bytes from the buffer.
-  buffer.get_cstring # Pulls a null-terminted string from the buffer.
+  buffer.get_cstring # Pulls a null-terminated string from the buffer.
   buffer.get_double # Pulls a 64-bit floating point from the buffer.
   buffer.get_int32 # Pulls a 32-bit integer (4 bytes) from the buffer.
   buffer.get_int64 # Pulls a 64-bit integer (8 bytes) from the buffer.
   buffer.get_string # Pulls a UTF-8 string from the buffer.
 
-Convertig a buffer to it's raw bytes, for example to send over a socket,
-is done by simply calling `to_s` on the buffer.
+Converting a buffer to its raw bytes (for example, for sending over a socket)
+is done by simply calling ``to_s`` on the buffer.
 
 .. code-block:: ruby
 
@@ -119,20 +118,20 @@ specific to the specification:
 ``BSON::Binary``
 ````````````````
 
-This is a representation of binary data, and must provide the raw data and
-a subtype when constructing.
+This is a representation of binary data. The raw data and a subtype must be
+provided when constructing.
 
 .. code-block:: ruby
 
   BSON::Binary.new(binary_data, :md5)
 
-Valid subtypes are: ``:generic``, ``:function``, ``:old``, ``:uuid_old``, ``:uuid``,
-``:md5``, ``:user``.
+Valid subtypes are: ``:generic``, ``:function``, ``:old``, ``:uuid_old``,
+``:uuid``, ``:md5``, ``:user``.
 
 ``BSON::Code``
 ``````````````
 
-Represents a string of Javascript code.
+Represents a string of JavaScript code.
 
 .. code-block:: ruby
 
@@ -141,7 +140,7 @@ Represents a string of Javascript code.
 ``BSON::CodeWithScope``
 ```````````````````````
 
-Represents a string of Javascript code with a hash of values.
+Represents a string of JavaScript code with a hash of values.
 
 .. code-block:: ruby
 
@@ -150,8 +149,8 @@ Represents a string of Javascript code with a hash of values.
 ``BSON::Document``
 ``````````````````
 
-This is a subclass of a hash that stores all keys as strings but allows access to
-them with symbol keys.
+This is a subclass of ``Hash`` that stores all keys as strings, but allows
+access to them with symbol keys.
 
 .. code-block:: ruby
 
@@ -206,8 +205,8 @@ Represents a placeholder for a value that was not provided.
 ``BSON::Decimal128``
 ````````````````````
 
-Represents a 128-bit decimal-based floating-point value capable of
-emulating decimal rounding with exact precision..
+Represents a 128-bit decimal-based floating-point value capable of emulating
+decimal rounding with exact precision.
 
 .. code-block:: ruby
 
@@ -260,8 +259,8 @@ them.
 Special Ruby Date Classes
 -------------------------
 
-Ruby's ``Date`` and ``DateTime`` are able to be serialized, but when
-they are deserialized they will always be returned as a ``Time`` since the BSON
+Ruby's ``Date`` and ``DateTime`` are able to be serialized, but when they are
+deserialized, they will always be returned as a ``Time`` since the BSON
 specification only has a ``Time`` type and knows nothing about Ruby.
 
 
@@ -302,7 +301,7 @@ Please use the ``Regexp::Raw`` class to instantiate your BSON regular expression
 pattern and options you want.
 
 When regular expressions are deserialized, they return a wrapper that holds the
-raw regex string, but does not compile it. In order to get the Ruby ``Regexp``
+raw regex string, but do not compile it. In order to get the Ruby ``Regexp``
 object, one must call ``compile`` on the returned object.
 
 .. code-block:: ruby


### PR DESCRIPTION
Similar to https://github.com/mongodb/docs-ecosystem/pull/367

Fixes some typos and changes copy for clarity and correctness.