### PR TITLE
Add support for #slice with symbol arguments

### DIFF
--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -192,6 +192,29 @@ module BSON
       end
     end
 
+
+
+    if instance_methods.include?(:slice)
+      # Slices a document to include only the given keys.
+      # Will normalize symbol keys into strings.
+      # (this method is backported from ActiveSupport::Hash)
+      #
+      # @example Get a document/hash with only the `name` and `age` fields present
+      #   document # => { _id: <ObjectId>, :name => 'John', :age => 30, :location => 'Earth' }
+      #   document.slice(:name, 'age') # => { name: 'John', age: 30 }
+      #   document.slice('name') # => { name: 'John' }
+      #   document.slice(:foo) # => nil
+      #
+      # @param [ Array<String, Symbol> ] *keys Keys, that will be kept in the resulting document
+      #
+      # @return [ BSON::Document ] The document with only the selected keys
+      #
+      # @since 4.3.1
+      def slice(*keys)
+        super(*keys.map{|key| convert_key(key)})
+      end
+    end
+
     private
 
     def convert_key(key)

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -192,8 +192,6 @@ module BSON
       end
     end
 
-
-
     if instance_methods.include?(:slice)
       # Slices a document to include only the given keys.
       # Will normalize symbol keys into strings.

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -118,6 +118,28 @@ describe BSON::Document do
     end
   end
 
+  if described_class.instance_methods.include?(:slice)
+    describe "#slice" do
+      let(:document) do
+        described_class.new("key1" => "value1", key2: "value2")
+      end
+
+      context "when provided string keys" do
+
+        it "returns the partial document" do
+          expect(document.slice("key1")).to contain_exactly(['key1', 'value1'])
+        end
+      end
+
+      context "when provided symbol keys" do
+
+        it "returns the partial document" do
+          expect(document.slice(:key1)).to contain_exactly(['key1', 'value1'])
+        end
+      end
+    end
+  end
+
   describe "#delete" do
 
     shared_examples_for "a document with deletable pairs" do


### PR DESCRIPTION
Since rails 5.2 dropped ActiveSupport::Hash#slice in favor of delegating to
ruby 2.5+ Hash#slice, this broke the working functionality of BSON::Document#slice
when used with symbol arguments for keys.

[ close RUBY-1322 ]