### PR TITLE
Bug fix for the BSON::ByteBuffer#put_byte and BSON::ByteBuffer#put_bytes methods

### DIFF
--- a/ext/bson/bson_native.c
+++ b/ext/bson/bson_native.c
@@ -760,6 +760,9 @@ VALUE pvt_read_field(byte_buffer_t *b, VALUE rb_buffer, uint8_t type){
  */
 VALUE rb_bson_byte_buffer_put_byte(VALUE self, VALUE byte)
 {
+  if (!RB_TYPE_P(byte, T_STRING))
+    rb_raise(rb_eArgError, "Invalid input");
+
   byte_buffer_t *b;
   const char *str = RSTRING_PTR(byte);
 
@@ -783,6 +786,9 @@ void pvt_put_byte( byte_buffer_t *b, const char byte)
  */
 VALUE rb_bson_byte_buffer_put_bytes(VALUE self, VALUE bytes)
 {
+  if (!RB_TYPE_P(bytes, T_STRING) && !RB_TYPE_P(bytes, RUBY_T_DATA))
+    rb_raise(rb_eArgError, "Invalid input");
+
   byte_buffer_t *b;
   const char *str = RSTRING_PTR(bytes);
   const size_t length = RSTRING_LEN(bytes);

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -202,6 +202,7 @@ describe BSON::ByteBuffer do
         expect{buffer.put_byte(1)}.to raise_error(ArgumentError)
       end
     end
+
     context 'when it receives a nil value' do
       it 'raises the ArgumentError exception' do
         expect{buffer.put_byte(nil)}.to raise_error(ArgumentError)
@@ -533,6 +534,7 @@ describe BSON::ByteBuffer do
         expect{buffer.put_bytes(1)}.to raise_error(ArgumentError)
       end
     end
+    
     context 'when it receives a nil value' do
       it 'raises the ArgumentError exception' do
         expect{buffer.put_bytes(nil)}.to raise_error(ArgumentError)

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -196,6 +196,17 @@ describe BSON::ByteBuffer do
     it 'increments the write position by 1' do
       expect(modified.write_position).to eq(1)
     end
+
+    context 'when it receives a numeric value' do
+      it 'raises the ArgumentError exception' do
+        expect{buffer.put_byte(1)}.to raise_error(ArgumentError)
+      end
+    end
+    context 'when it receives a nil value' do
+      it 'raises the ArgumentError exception' do
+        expect{buffer.put_byte(nil)}.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#put_cstring' do
@@ -499,6 +510,33 @@ describe BSON::ByteBuffer do
       end
 
       it_behaves_like 'a rewindable buffer'
+    end
+  end
+
+  describe '#put_bytes' do
+
+    let(:buffer) do
+      described_class.new
+    end
+
+    let!(:modified) do
+      buffer.put_bytes(BSON::Int32::BSON_TYPE)
+      buffer
+    end
+
+    it 'increments the write position by 1' do
+      expect(modified.write_position).to eq(1)
+    end
+
+    context 'when it receives a numeric value' do
+      it 'raises the ArgumentError exception' do
+        expect{buffer.put_bytes(1)}.to raise_error(ArgumentError)
+      end
+    end
+    context 'when it receives a nil value' do
+      it 'raises the ArgumentError exception' do
+        expect{buffer.put_bytes(nil)}.to raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -36,6 +36,7 @@ import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import java.math.BigInteger;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 
@@ -276,9 +277,15 @@ public class ByteBuf extends RubyObject {
    * @version 4.0.0
    */
   @JRubyMethod(name = "put_byte")
-  public ByteBuf putByte(final IRubyObject value) {
+  public ByteBuf putByte(ThreadContext context, final IRubyObject value) {
+    RubyString string;
+    try {
+      string = (RubyString) value;
+    } catch (ClassCastException e) {
+      throw context.runtime.newArgumentError(e.toString());
+    }
     ensureBsonWrite(1);
-    this.buffer.put(((RubyString) value).getBytes()[0]);
+    this.buffer.put(string.getBytes()[0]);
     this.writePosition += 1;
     return this;
   }
@@ -293,8 +300,14 @@ public class ByteBuf extends RubyObject {
    * @version 4.0.0
    */
   @JRubyMethod(name = "put_bytes")
-  public ByteBuf putBytes(final IRubyObject value) {
-    byte[] bytes = ((RubyString) value).getBytes();
+  public ByteBuf putBytes(ThreadContext context, final IRubyObject value) {
+    RubyString string;
+    try {
+      string = (RubyString) value;
+    } catch (ClassCastException e) {
+      throw context.runtime.newArgumentError(e.toString());
+    }
+    byte[] bytes = string.getBytes();
     ensureBsonWrite(bytes.length);
     this.buffer.put(bytes);
     this.writePosition += bytes.length;


### PR DESCRIPTION
Hi,

The BSON::ByteBuffer#put_byte and BSON::ByteBuffer#put_bytes methods are crashing ruby when they receive parameters different to a String or a ByteBuffer object:

I added a couple of cases to reproduce this problem:
```
require 'bson'
BSON::ByteBuffer.new(1)
BSON::ByteBuffer.put_byte(1.2)
BSON::ByteBuffer.put_bytes([1])
```

If any of those 2 methods are invoked with an unexpected parameter, they are going to crash Ruby.

I tested it in ruby 2.4.3p205 and 2.5.1p57 in machines running MacOS and Linux (both x86_64) and I added  the output of one of those cases:
```
-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0023 p:---- s:0115 e:000114 CFUNC  :initialize
c:0022 p:---- s:0112 e:000111 CFUNC  :new
c:0021 p:0015 s:0107 e:000106 EVAL   (irb):3 [FINISH]
c:0020 p:---- s:0104 e:000103 CFUNC  :eval
c:0019 p:0025 s:0096 e:000095 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/workspace.rb:87
c:0018 p:0027 s:0088 e:000086 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/context.rb:381
c:0017 p:0012 s:0081 e:000080 METHOD /Users/ruby/.rvm/gems/ruby-2.4.3/gems/fancy_irb-1.1.0/lib/fancy_irb/irb_ext.rb:31
c:0016 p:0024 s:0076 e:000075 BLOCK  /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:493
c:0015 p:0041 s:0067 e:000066 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:627
c:0014 p:0030 s:0061 e:000060 METHOD /Users/ruby/.rvm/gems/ruby-2.4.3/gems/fancy_irb-1.1.0/lib/fancy_irb/irb_ext.rb:19
c:0013 p:0011 s:0054 E:000a00 BLOCK  /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:490
c:0012 p:0128 s:0049 e:000048 BLOCK  /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:246 [FINISH]
c:0011 p:---- s:0045 e:000044 CFUNC  :loop
c:0010 p:0009 s:0041 e:000040 BLOCK  /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:232 [FINISH]
c:0009 p:---- s:0038 e:000037 CFUNC  :catch
c:0008 p:0018 s:0033 e:000032 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:231
c:0007 p:0037 s:0029 E:000670 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:489
c:0006 p:0008 s:0025 e:000024 BLOCK  /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:430 [FINISH]
c:0005 p:---- s:0022 e:000021 CFUNC  :catch
c:0004 p:0075 s:0017 E:0007d8 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:429
c:0003 p:0118 s:0012 e:000011 METHOD /Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:385
c:0002 p:0023 s:0006 e:000005 EVAL   /Users/ruby/.rvm/rubies/ruby-2.4.3/bin/irb:11 [FINISH]
c:0001 p:0000 s:0003 E:000b50 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
/Users/ruby/.rvm/rubies/ruby-2.4.3/bin/irb:11:in `<main>'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:385:in `start'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:429:in `run'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:429:in `catch'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:430:in `block in run'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:489:in `eval_input'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:231:in `each_top_level_statement'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:231:in `catch'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:232:in `block in each_top_level_statement'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:232:in `loop'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/ruby-lex.rb:246:in `block (2 levels) in each_top_level_statement'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:490:in `block in eval_input'
/Users/ruby/.rvm/gems/ruby-2.4.3/gems/fancy_irb-1.1.0/lib/fancy_irb/irb_ext.rb:19:in `signal_status'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:627:in `signal_status'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb.rb:493:in `block (2 levels) in eval_input'
/Users/ruby/.rvm/gems/ruby-2.4.3/gems/fancy_irb-1.1.0/lib/fancy_irb/irb_ext.rb:31:in `evaluate'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/context.rb:381:in `evaluate'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/workspace.rb:87:in `evaluate'
/Users/ruby/.rvm/rubies/ruby-2.4.3/lib/ruby/2.4.0/irb/workspace.rb:87:in `eval'
(irb):3:in `irb_binding'
(irb):3:in `new'
(irb):3:in `initialize'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000000 rbx: 0x0000000000000c21 rcx: 0x0000000104c9f360
 rdx: 0x00007fe5a6801428 rdi: 0x0000000000000001 rsi: 0x0000000104c9f360
 rbp: 0x00007ffeeb34c8e0 rsp: 0x00007ffeeb34c8c0  r8: 0x00007fe5a6801428
  r9: 0x00000001058e9b80 r10: 0x00007ffeeb34c9f8 r11: 0x0000000104c9f360
 r12: 0x00000000ffffffff r13: 0x00007fe5a605f460 r14: 0x00007fe5a6801428
 r15: 0x0000000000000003 rip: 0x00000001058e9ba5 rfl: 0x0000000000010293

-- C level backtrace information -------------------------------------------
0   libruby.2.4.3.dylib                 0x0000000104a85517 rb_vm_bugreport + 135
1   libruby.2.4.3.dylib                 0x000000010491e048 rb_bug_context + 472
2   libruby.2.4.3.dylib                 0x00000001049ffad8 sigsegv + 72
3   libsystem_platform.dylib            0x00007fff5495ef5a _sigtramp + 26
4   native.bundle                       0x00000001058e9ba5 rb_bson_byte_buffer_initialize + 37
5   libruby.2.4.3.dylib                 0x0000000104a7fada vm_call0_body + 506
6   libruby.2.4.3.dylib                 0x0000000104a8079d rb_call0 + 205
7   libruby.2.4.3.dylib                 0x0000000104987689 rb_class_new_instance + 41
8   libruby.2.4.3.dylib                 0x0000000104a79140 vm_call_cfunc + 272
9   libruby.2.4.3.dylib                 0x0000000104a63888 vm_exec_core + 11880
10  libruby.2.4.3.dylib                 0x0000000104a73e54 vm_exec + 116
11  libruby.2.4.3.dylib                 0x0000000104a8171d eval_string_with_cref + 1277
12  libruby.2.4.3.dylib                 0x0000000104a6f8de rb_f_eval + 334
13  libruby.2.4.3.dylib                 0x0000000104a79140 vm_call_cfunc + 272
14  libruby.2.4.3.dylib                 0x0000000104a63888 vm_exec_core + 11880
15  libruby.2.4.3.dylib                 0x0000000104a73e54 vm_exec + 116
16  libruby.2.4.3.dylib                 0x0000000104a80a7f invoke_block_from_c_splattable + 495
17  libruby.2.4.3.dylib                 0x0000000104a81a53 loop_i + 35
18  libruby.2.4.3.dylib                 0x0000000104927cc3 rb_rescue2 + 275
19  libruby.2.4.3.dylib                 0x0000000104a79140 vm_call_cfunc + 272
20  libruby.2.4.3.dylib                 0x0000000104a630b6 vm_exec_core + 9878
21  libruby.2.4.3.dylib                 0x0000000104a73e54 vm_exec + 116
22  libruby.2.4.3.dylib                 0x0000000104a80a7f invoke_block_from_c_splattable + 495
23  libruby.2.4.3.dylib                 0x0000000104a819ee catch_i + 78
24  libruby.2.4.3.dylib                 0x0000000104a70a7c vm_catch_protect + 156
25  libruby.2.4.3.dylib                 0x0000000104a71152 rb_f_catch + 66
26  libruby.2.4.3.dylib                 0x0000000104a79140 vm_call_cfunc + 272
27  libruby.2.4.3.dylib                 0x0000000104a630b6 vm_exec_core + 9878
28  libruby.2.4.3.dylib                 0x0000000104a73e54 vm_exec + 116
29  libruby.2.4.3.dylib                 0x0000000104a80a7f invoke_block_from_c_splattable + 495
30  libruby.2.4.3.dylib                 0x0000000104a819ee catch_i + 78
31  libruby.2.4.3.dylib                 0x0000000104a70a7c vm_catch_protect + 156
32  libruby.2.4.3.dylib                 0x0000000104a71152 rb_f_catch + 66
33  libruby.2.4.3.dylib                 0x0000000104a79140 vm_call_cfunc + 272
34  libruby.2.4.3.dylib                 0x0000000104a630b6 vm_exec_core + 9878
35  libruby.2.4.3.dylib                 0x0000000104a73e54 vm_exec + 116
36  libruby.2.4.3.dylib                 0x0000000104926f5a ruby_exec_internal + 138
37  libruby.2.4.3.dylib                 0x0000000104926e78 ruby_run_node + 56
38  ruby                                0x00000001048b0f2f main + 79

-- Other runtime information -----------------------------------------------

* Loaded script: irb

```

I also tried to fix this error but I'm not sure if I used the correct approach to address this problem.

I will appreciate any advice to improve those changes.