### PR TITLE
RUBY-1677 Fix BSON::Document#fetch method signature

### DIFF
--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -37,15 +37,30 @@ module BSON
     # Get a value from the document for the provided key. Can use string or
     # symbol access, with string access being the faster of the two.
     #
+    # @overload fetch(key)
+    #   Returns a value from the hash for the given key. If the key does
+    #   not exist, raises KeyError exception.
+    #
+    # @overload fetch(key, default)
+    #   Returns a value from the hash for the given key. If the key does not
+    #   exist, returns *default*.
+    #
+    # @overload fetch(key, &block)
+    #   Returns a value from the hash for the given key. If the key does not
+    #   exist, returns the value of the block called with the key.
+    #
     # @example Get an element for the key.
     #   document.fetch("field")
     #
-    # @example Get an element for the key by symbol.
-    #   document.fetch(:field)
+    # @example Get an element for the key by symbol with a default.
+    #   document.fetch(:field, 'foo')
+    #
+    # @example Get an element for the key by symbol with a block default.
+    #   document.fetch(:field) { |key| key.upcase }
     #
     # @param [ String, Symbol ] key The key to look up.
-    # @param [ Object ] default Returned value if key does not exist
-    # @yield [key] Block returning default value for given key
+    # @param [ Object ] default Returned value if key does not exist.
+    # @yield [key] Block returning default value for the given key.
     #
     # @return [ Object ] The found value. Raises KeyError if none found.
     #

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -44,12 +44,15 @@ module BSON
     #   document.fetch(:field)
     #
     # @param [ String, Symbol ] key The key to look up.
+    # @param [ Object ] default Returned value if key does not exist
+    # @yield [key] Block returning default value for given key
     #
     # @return [ Object ] The found value. Raises KeyError if none found.
     #
     # @since 4.4.0
-    def fetch(key)
-      super(convert_key(key))
+    def fetch(key, *args, &block)
+      key = convert_key(key)
+      super(key, *args, &block)
     end
 
     # Get a value from the document for the provided key. Can use string or

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -76,6 +76,31 @@ describe BSON::Document do
           document.fetch(:non_existent_key)
         end.to raise_exception(KeyError)
       end
+
+      context "and default value was provided" do
+
+        it "returns default value" do
+          expect(document.fetch(:non_existent_key, false)).to eq(false)
+        end
+      end
+
+      context "and block was passed" do
+
+        it "returns result of the block" do
+          expect(document.fetch(:non_existent_key, &:to_s))
+            .to eq("non_existent_key")
+        end
+      end
+    end
+
+    context "when key exists" do
+
+      context "and default value is provided" do
+
+        it "returns the value" do
+          expect(document.fetch(:key, "other")).to eq("value")
+        end
+      end
     end
   end
 

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -77,14 +77,14 @@ describe BSON::Document do
         end.to raise_exception(KeyError)
       end
 
-      context "and default value was provided" do
+      context "and default value is provided" do
 
         it "returns default value" do
           expect(document.fetch(:non_existent_key, false)).to eq(false)
         end
       end
 
-      context "and block was passed" do
+      context "and block is passed" do
 
         it "returns result of the block" do
           expect(document.fetch(:non_existent_key, &:to_s))
@@ -99,6 +99,13 @@ describe BSON::Document do
 
         it "returns the value" do
           expect(document.fetch(:key, "other")).to eq("value")
+        end
+      end
+
+      context "and block is passed" do
+
+        it "returns the value" do
+          expect(document.fetch(:key, &:to_s)).to eq("value")
         end
       end
     end


### PR DESCRIPTION
JIRA link: https://jira.mongodb.org/browse/RUBY-1677

After adding the `fetch` method (in #99) it changed it's signature. This PR makes sure it's the same as Ruby's `Hash#fetch`