### PR TITLE
RUBY-1702 Skip creating Time instance in Date serialization

### DIFF
--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -16,6 +16,16 @@ require 'date'
 
 module BSON
 
+  # Julian day of Date 1970-01-01 - UNIX timestamp reference.
+  #
+  # @api private
+  DATE_REFERENCE = ::Date.new(1970, 1, 1).jd
+
+  # Number of miliseconds in a day.
+  #
+  # @api private
+  MILLISECONDS_IN_DAY = 60 * 60 * 24 * 1_000
+
   # Injects behaviour for encoding date values to raw bytes as specified by
   # the BSON spec for time.
   #
@@ -23,17 +33,6 @@ module BSON
   #
   # @since 2.1.0
   module Date
-
-    # Julian day of Date 1970-01-01 - UNIX timestamp reference.
-    # Equivalent of ::Date.new(1970, 1, 1).jd
-    #
-    # @api private
-    REFERENCE = 2440588
-
-    # Number of miliseconds in a day.
-    #
-    # @api private
-    MILLISECONDS_IN_DAY = 60 * 60 * 24 * 1_000
 
     # Get the date as encoded BSON.
     #
@@ -46,7 +45,7 @@ module BSON
     #
     # @since 2.1.0
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
-      buffer.put_int64((jd - REFERENCE) * MILLISECONDS_IN_DAY)
+      buffer.put_int64((jd - DATE_REFERENCE) * MILLISECONDS_IN_DAY)
     end
 
     # Get the BSON type for the date.

--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -24,12 +24,16 @@ module BSON
   # @since 2.1.0
   module Date
 
-    # Julian day of Date 1970-01-01 - UNIX timestamp reference
+    # Julian day of Date 1970-01-01 - UNIX timestamp reference.
     # Equivalent of ::Date.new(1970, 1, 1).jd
+    #
+    # @api private
     REFERENCE = 2440588
 
-    # Amount of miliseconds in a day
-    MILISECONDS_IN_DAY = 60 * 60 * 24 * 1_000
+    # Number of miliseconds in a day.
+    #
+    # @api private
+    MILLISECONDS_IN_DAY = 60 * 60 * 24 * 1_000
 
     # Get the date as encoded BSON.
     #
@@ -42,7 +46,7 @@ module BSON
     #
     # @since 2.1.0
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
-      buffer.put_int64((jd - REFERENCE) * MILISECONDS_IN_DAY)
+      buffer.put_int64((jd - REFERENCE) * MILLISECONDS_IN_DAY)
     end
 
     # Get the BSON type for the date.

--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -24,6 +24,13 @@ module BSON
   # @since 2.1.0
   module Date
 
+    # Julian day of Date 1970-01-01 - UNIX timestamp reference
+    # Equivalent of ::Date.new(1970, 1, 1).jd
+    REFERENCE = 2440588
+
+    # Amount of miliseconds in a day
+    MILISECONDS_IN_DAY = 60 * 60 * 24 * 1_000
+
     # Get the date as encoded BSON.
     #
     # @example Get the date as encoded BSON.
@@ -35,7 +42,7 @@ module BSON
     #
     # @since 2.1.0
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
-      ::Time.utc(year, month, day).to_bson(buffer)
+      buffer.put_int64((jd - REFERENCE) * MILISECONDS_IN_DAY)
     end
 
     # Get the BSON type for the date.


### PR DESCRIPTION
JIRA: [RUBY-1702](https://jira.mongodb.org/browse/RUBY-1702)

I haven't found any nice solution for DateTimes - there is no way to get [`df`](https://github.com/ruby/date/blob/master/ext/date/date_core.c#L7113) attribute - which apparently holds second since beginning of day. I could use things like `offset`/`sec_fraction` etc., but this would be much harder to read + would actually create more instances (of Rational) than just using `to_time` as in current implementation.