### PR TITLE
RUBY-1958 Add GitHub repository URL to gemspec

### DIFF
--- a/bson.gemspec
+++ b/bson.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |s|
   s.description       = 'A full featured BSON specification implementation, in Ruby'
   s.license           = 'Apache-2.0'
 
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/mongodb/bson-ruby'
+  }
+
   if File.exists?('gem-private_key.pem')
     s.signing_key = 'gem-private_key.pem'
     s.cert_chain  = ['gem-public_cert.pem']

--- a/bson.gemspec
+++ b/bson.gemspec
@@ -16,9 +16,12 @@ Gem::Specification.new do |s|
   s.description       = 'A full featured BSON specification implementation, in Ruby'
   s.license           = 'Apache-2.0'
 
-  s.metadata = {
-    'source_code_uri' => 'https://github.com/mongodb/bson-ruby'
-  }
+  # Ruby 1.9 does not support metadata
+  if s.respond_to?(:metadata=)
+    s.metadata = {
+      'source_code_uri' => 'https://github.com/mongodb/bson-ruby'
+    }
+  end
 
   if File.exists?('gem-private_key.pem')
     s.signing_key = 'gem-private_key.pem'


### PR DESCRIPTION
Purpose:
- This change adds the link to the gem page on <https://rubygems.org>.
- This allows 3rd-party tools (e.g. Dependabot) to generate links to the repository, compare page, releases page, and so on.

See also:
- https://guides.rubygems.org/specification-reference/#metadata
- https://rubygems.org/gems/bson

Example:
- https://rubygems.org/gems/rspec-rails
- https://github.com/rspec/rspec-rails/blob/v3.8.2/rspec-rails.gemspec#L16-L22
![image](https://user-images.githubusercontent.com/473530/58294680-72a79680-7e06-11e9-9457-1852c8b5f984.png)
