### PR TITLE
Return the original document as the normalized document

### DIFF
--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -207,6 +207,17 @@ module BSON
 
     alias :update :merge!
 
+    # Returns a normalized BSON value, which is the original document.
+    #
+    # @example Return the valid BSON document
+    #   document.to_bson_normalized_value
+    #
+    # @return [ BSON::Document ] The original document.
+    #
+    def to_bson_normalized_value
+      self
+    end
+
     if instance_methods.include?(:dig)
       # Retrieves the value object corresponding to the each key objects repeatedly.
       # Will normalize symbol keys into strings.

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -163,6 +163,14 @@ describe BSON::Document do
     it "sets the value" do
       expect(doc[key]).to eq(val)
     end
+
+    context "the value is a BSON::Document" do
+      let(:val) { described_class.new }
+
+      it "returns the same object" do
+        expect(doc[key].object_id).to eq(val.object_id)
+      end
+    end
   end
 
   if described_class.instance_methods.include?(:dig)
@@ -280,6 +288,13 @@ describe BSON::Document do
 
     it "returns the key/value pairs as an array" do
       expect(doc.to_a).to eq(keys.zip(vals))
+    end
+  end
+
+  describe "#to_bson_normalized_value" do
+
+    it "returns itself" do
+      expect(doc.to_bson_normalized_value.object_id).to eq(doc.object_id)
     end
   end
 


### PR DESCRIPTION
`BSON::Document` currently inherits `#to_bson_normalized_value` from `Hash` and unnecessarily casts itself into a new document. This creates some unexpected behavior:

```ruby
[1] pry(main)> require "bson"
=> true
[2] pry(main)> doc = BSON::Document.new
=> {}
[3] pry(main)> val = BSON::Document.new
=> {}
[4] pry(main)> doc["key"] = val
=> {}
[5] pry(main)> val.object_id == doc["key"].object_id
=> false
```

This new behavior doesn't cast a provided BSON::Document to a new document, saving performance and memory, while providing expected behavior.

```ruby
[4] pry(main)> doc = BSON::Document.new
=> {}
[5] pry(main)> val = BSON::Document.new
=> {}
[6] pry(main)> doc["key"] = val
=> {}
[7] pry(main)> val.object_id == doc["key"].object_id
=> true
```