### PR TITLE
RUBY-1959 Specify exact reason in "invalid utf-8" exceptions

### DIFF
--- a/ext/bson/bson_native.c
+++ b/ext/bson/bson_native.c
@@ -19,6 +19,7 @@
 #include <time.h>
 #include <unistd.h>
 #include "native-endian.h"
+#include "bson_native.h"
 
 #define BSON_BYTE_BUFFER_SIZE 1024
 
@@ -95,7 +96,6 @@ static size_t rb_bson_byte_buffer_memsize(const void *ptr);
 static void rb_bson_byte_buffer_free(void *ptr);
 static void rb_bson_expand_buffer(byte_buffer_t* buffer_ptr, size_t length);
 static void rb_bson_generate_machine_id(VALUE rb_md5_class, char *rb_bson_machine_id);
-static bool rb_bson_utf8_validate(const char *utf8, size_t utf8_len, bool allow_null);
 
 static const rb_data_type_t rb_byte_buffer_data_type = {
   "bson/byte_buffer",
@@ -1175,170 +1175,4 @@ VALUE rb_bson_object_id_generator_next(int argc, VALUE* args, VALUE self)
   memcpy(&bytes[9], &c, 3);
   rb_bson_object_id_counter++;
   return rb_str_new(bytes, 12);
-}
-
-/**
- * Taken from libbson.
- */
-static void _bson_utf8_get_sequence(const char *utf8, uint8_t *seq_length, uint8_t *first_mask)
-{
- unsigned char c = *(const unsigned char *)utf8;
- uint8_t m;
- uint8_t n;
-
- /*
-  * See the following[1] for a description of what the given multi-byte
-  * sequences will be based on the bits set of the first byte. We also need
-  * to mask the first byte based on that.  All subsequent bytes are masked
-  * against 0x3F.
-  *
-  * [1] http://www.joelonsoftware.com/articles/Unicode.html
-  */
-
- if ((c & 0x80) == 0) {
-  n = 1;
-  m = 0x7F;
- } else if ((c & 0xE0) == 0xC0) {
-  n = 2;
-  m = 0x1F;
- } else if ((c & 0xF0) == 0xE0) {
-  n = 3;
-  m = 0x0F;
- } else if ((c & 0xF8) == 0xF0) {
-  n = 4;
-  m = 0x07;
- } else if ((c & 0xFC) == 0xF8) {
-  n = 5;
-  m = 0x03;
- } else if ((c & 0xFE) == 0xFC) {
-  n = 6;
-  m = 0x01;
- } else {
-  n = 0;
-  m = 0;
- }
-
- *seq_length = n;
- *first_mask = m;
-}
-
-/**
- * Taken from libbson.
- */
-bool rb_bson_utf8_validate(const char *utf8, size_t utf8_len, bool allow_null)
-{
-  uint32_t c;
-  uint8_t first_mask;
-  uint8_t seq_length;
-  unsigned i;
-  unsigned j;
-
-  if (!utf8) {
-    return false;
-  }
-
-  for (i = 0; i < utf8_len; i += seq_length) {
-    _bson_utf8_get_sequence(&utf8[i], &seq_length, &first_mask);
-
-    /*
-     * Ensure we have a valid multi-byte sequence length.
-     */
-    if (!seq_length) {
-      return false;
-    }
-
-    /*
-     * Ensure we have enough bytes left.
-     */
-    if ((utf8_len - i) < seq_length) {
-      return false;
-    }
-
-    /*
-     * Also calculate the next char as a unichar so we can
-     * check code ranges for non-shortest form.
-     */
-    c = utf8 [i] & first_mask;
-
-    /*
-     * Check the high-bits for each additional sequence byte.
-     */
-    for (j = i + 1; j < (i + seq_length); j++) {
-      c = (c << 6) | (utf8 [j] & 0x3F);
-      if ((utf8[j] & 0xC0) != 0x80) {
-        return false;
-      }
-    }
-
-    /*
-     * Check for NULL bytes afterwards.
-     *
-     * Hint: if you want to optimize this function, starting here to do
-     * this in the same pass as the data above would probably be a good
-     * idea. You would add a branch into the inner loop, but save possibly
-     * on cache-line bouncing on larger strings. Just a thought.
-     */
-    if (!allow_null) {
-      for (j = 0; j < seq_length; j++) {
-        if (((i + j) > utf8_len) || !utf8[i + j]) {
-          return false;
-        }
-      }
-    }
-
-    /*
-     * Code point wont fit in utf-16, not allowed.
-     */
-    if (c > 0x0010FFFF) {
-      return false;
-    }
-
-    /*
-     * Byte is in reserved range for UTF-16 high-marks
-     * for surrogate pairs.
-     */
-    if ((c & 0xFFFFF800) == 0xD800) {
-      return false;
-    }
-
-    /*
-     * Check non-shortest form unicode.
-     */
-    switch (seq_length) {
-    case 1:
-      if (c <= 0x007F) {
-        continue;
-      }
-      return false;
-
-    case 2:
-      if ((c >= 0x0080) && (c <= 0x07FF)) {
-        continue;
-      } else if (c == 0) {
-        /* Two-byte representation for NULL. */
-        continue;
-      }
-      return false;
-
-    case 3:
-      if (((c >= 0x0800) && (c <= 0x0FFF)) ||
-         ((c >= 0x1000) && (c <= 0xFFFF))) {
-        continue;
-      }
-      return false;
-
-    case 4:
-      if (((c >= 0x10000) && (c <= 0x3FFFF)) ||
-         ((c >= 0x40000) && (c <= 0xFFFFF)) ||
-         ((c >= 0x100000) && (c <= 0x10FFFF))) {
-        continue;
-      }
-      return false;
-
-    default:
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/ext/bson/bson_native.c
+++ b/ext/bson/bson_native.c
@@ -827,9 +827,7 @@ VALUE rb_bson_byte_buffer_put_bson_partial_string(VALUE self, const char *str, i
 void pvt_put_cstring(byte_buffer_t *b, const char *str, int32_t length)
 {
   int bytes_to_write;
-  if (!rb_bson_utf8_validate(str, length, false)) {
-    rb_raise(rb_eArgError, "String %s is not a valid UTF-8 CString.", str);
-  }
+  rb_bson_utf8_validate(str, length, false);
   bytes_to_write = length + 1;
   ENSURE_BSON_WRITE(b, bytes_to_write);
   memcpy(WRITE_PTR(b), str, bytes_to_write);
@@ -1008,9 +1006,7 @@ static VALUE rb_bson_byte_buffer_put_bson_string(VALUE self, const char *str, in
 
   length_le = BSON_UINT32_TO_LE(length);
 
-  if (!rb_bson_utf8_validate(str, length - 1, true)) {
-    rb_raise(rb_eArgError, "String %s is not valid UTF-8.", str);
-  }
+  rb_bson_utf8_validate(str, length - 1, true);
 
   TypedData_Get_Struct(self, byte_buffer_t, &rb_byte_buffer_data_type, b);
   ENSURE_BSON_WRITE(b, length + 4);

--- a/ext/bson/bson_native.h
+++ b/ext/bson/bson_native.h
@@ -1,0 +1,7 @@
+#include <stdbool.h>
+#include <unistd.h>
+
+void
+rb_bson_utf8_validate (const char *utf8, /* IN */
+                    size_t utf8_len,  /* IN */
+                    bool allow_null);  /* IN */

--- a/ext/bson/libbson-utf8.c
+++ b/ext/bson/libbson-utf8.c
@@ -1,0 +1,224 @@
+#include <ruby.h>
+#include <ruby/encoding.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <assert.h>
+#include "bson_native.h"
+
+/**
+ * Taken from libbson.
+ */
+
+#define BSON_ASSERT assert
+#define BSON_INLINE
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
+ * _bson_utf8_get_sequence --
+ *
+ *       Determine the sequence length of the first UTF-8 character in
+ *       @utf8. The sequence length is stored in @seq_length and the mask
+ *       for the first character is stored in @first_mask.
+ *
+ * Returns:
+ *       None.
+ *
+ * Side effects:
+ *       @seq_length is set.
+ *       @first_mask is set.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static BSON_INLINE void
+_bson_utf8_get_sequence (const char *utf8,    /* IN */
+                         uint8_t *seq_length, /* OUT */
+                         uint8_t *first_mask) /* OUT */
+{
+   unsigned char c = *(const unsigned char *) utf8;
+   uint8_t m;
+   uint8_t n;
+
+   /*
+    * See the following[1] for a description of what the given multi-byte
+    * sequences will be based on the bits set of the first byte. We also need
+    * to mask the first byte based on that.  All subsequent bytes are masked
+    * against 0x3F.
+    *
+    * [1] http://www.joelonsoftware.com/articles/Unicode.html
+    */
+
+   if ((c & 0x80) == 0) {
+      n = 1;
+      m = 0x7F;
+   } else if ((c & 0xE0) == 0xC0) {
+      n = 2;
+      m = 0x1F;
+   } else if ((c & 0xF0) == 0xE0) {
+      n = 3;
+      m = 0x0F;
+   } else if ((c & 0xF8) == 0xF0) {
+      n = 4;
+      m = 0x07;
+   } else {
+      n = 0;
+      m = 0;
+   }
+
+   *seq_length = n;
+   *first_mask = m;
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
+ * bson_utf8_validate --
+ *
+ *       Validates that @utf8 is a valid UTF-8 string. Note that we only
+ *       support UTF-8 characters which have sequence length less than or equal
+ *       to 4 bytes (RFC 3629).
+ *
+ *       If @allow_null is true, then \0 is allowed within @utf8_len bytes
+ *       of @utf8.  Generally, this is bad practice since the main point of
+ *       UTF-8 strings is that they can be used with strlen() and friends.
+ *       However, some languages such as Python can send UTF-8 encoded
+ *       strings with NUL's in them.
+ *
+ * Parameters:
+ *       @utf8: A UTF-8 encoded string.
+ *       @utf8_len: The length of @utf8 in bytes.
+ *       @allow_null: If \0 is allowed within @utf8, exclusing trailing \0.
+ *
+ * Returns:
+ *       true if @utf8 is valid UTF-8. otherwise false.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bool
+rb_bson_utf8_validate (const char *utf8, /* IN */
+                    size_t utf8_len,  /* IN */
+                    bool allow_null)  /* IN */
+{
+   uint32_t c;
+   uint8_t first_mask;
+   uint8_t seq_length;
+   unsigned i;
+   unsigned j;
+
+   BSON_ASSERT (utf8);
+
+   for (i = 0; i < utf8_len; i += seq_length) {
+      _bson_utf8_get_sequence (&utf8[i], &seq_length, &first_mask);
+
+      /*
+       * Ensure we have a valid multi-byte sequence length.
+       */
+      if (!seq_length) {
+         return false;
+      }
+
+      /*
+       * Ensure we have enough bytes left.
+       */
+      if ((utf8_len - i) < seq_length) {
+         return false;
+      }
+
+      /*
+       * Also calculate the next char as a unichar so we can
+       * check code ranges for non-shortest form.
+       */
+      c = utf8[i] & first_mask;
+
+      /*
+       * Check the high-bits for each additional sequence byte.
+       */
+      for (j = i + 1; j < (i + seq_length); j++) {
+         c = (c << 6) | (utf8[j] & 0x3F);
+         if ((utf8[j] & 0xC0) != 0x80) {
+            return false;
+         }
+      }
+
+      /*
+       * Check for NULL bytes afterwards.
+       *
+       * Hint: if you want to optimize this function, starting here to do
+       * this in the same pass as the data above would probably be a good
+       * idea. You would add a branch into the inner loop, but save possibly
+       * on cache-line bouncing on larger strings. Just a thought.
+       */
+      if (!allow_null) {
+         for (j = 0; j < seq_length; j++) {
+            if (((i + j) > utf8_len) || !utf8[i + j]) {
+               return false;
+            }
+         }
+      }
+
+      /*
+       * Code point won't fit in utf-16, not allowed.
+       */
+      if (c > 0x0010FFFF) {
+         return false;
+      }
+
+      /*
+       * Byte is in reserved range for UTF-16 high-marks
+       * for surrogate pairs.
+       */
+      if ((c & 0xFFFFF800) == 0xD800) {
+         return false;
+      }
+
+      /*
+       * Check non-shortest form unicode.
+       */
+      switch (seq_length) {
+      case 1:
+         if (c <= 0x007F) {
+            continue;
+         }
+         return false;
+
+      case 2:
+         if ((c >= 0x0080) && (c <= 0x07FF)) {
+            continue;
+         } else if (c == 0) {
+            /* Two-byte representation for NULL. */
+            if (!allow_null) {
+               return false;
+            }
+            continue;
+         }
+         return false;
+
+      case 3:
+         if (((c >= 0x0800) && (c <= 0x0FFF)) ||
+             ((c >= 0x1000) && (c <= 0xFFFF))) {
+            continue;
+         }
+         return false;
+
+      case 4:
+         if (((c >= 0x10000) && (c <= 0x3FFFF)) ||
+             ((c >= 0x40000) && (c <= 0xFFFFF)) ||
+             ((c >= 0x100000) && (c <= 0x10FFFF))) {
+            continue;
+         }
+         return false;
+
+      default:
+         return false;
+      }
+   }
+
+   return true;
+}

--- a/ext/bson/libbson-utf8.c
+++ b/ext/bson/libbson-utf8.c
@@ -159,7 +159,7 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
       if (!allow_null) {
          for (j = 0; j < seq_length; j++) {
             if (((i + j) > utf8_len) || !utf8[i + j]) {
-               rb_raise(rb_eArgError, "String %s contains NULL bytes", utf8);
+               rb_raise(rb_eArgError, "String %s contains null bytes", utf8);
             }
          }
       }
@@ -196,7 +196,7 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
          } else if (c == 0) {
             /* Two-byte representation for NULL. */
             if (!allow_null) {
-               rb_raise(rb_eArgError, "String %s contains NULL bytes", utf8);
+               rb_raise(rb_eArgError, "String %s contains null bytes", utf8);
             }
             continue;
          }


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1959