### PR TITLE
RUBY-1978 Consistently handle data not in UTF-8 when writing strings/symbols

### DIFF
--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -129,8 +129,8 @@ void Init_bson_native()
    *   buffer.put_cstring(obj) -> ByteBuffer
    *
    * Converts +obj+ to a string, which must not contain any null bytes, and
-   * writes the string to the buffer. +obj+ can be an instance of String,
-   * Symbol or Fixnum.
+   * which must be valid UTF-8, and writes the string to the buffer.
+   * +obj+ can be an instance of String, Symbol or Fixnum.
    *
    * If the string serialization of +obj+ contains null bytes, this method
    * raises +ArgumentError+. If +obj+ is of an unsupported type, this method

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -154,6 +154,10 @@ void Init_bson_native()
    *
    * The symbol may contain null bytes.
    *
+   * The symbol value is assumed to be encoded in UTF-8. If the symbol value
+   * contains bytes or byte sequences that are not valid in UTF-8, this method
+   * raises +EncodingError+.
+   *
    * Note: due to the string conversion, a symbol written to the buffer becomes
    * indistinguishable from a string with the same value written to the buffer.
    */

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -110,15 +110,22 @@ void Init_bson_native()
 
   /*
    * call-seq:
-   *   buffer.put_string(binary_str) -> ByteBuffer
+   *   buffer.put_string(str) -> ByteBuffer
    *
-   * Writes the specified byte string to the byte buffer as a BSON string.
+   * Writes the specified string to the byte buffer as a BSON string.
    *
-   * Unlike +put_bytes+, this method writes the provided byte string as
+   * Unlike #put_bytes, this method writes the provided byte string as
    * a "BSON string" - the string is prefixed with its length and suffixed
    * with a null byte. The byte string may contain null bytes itself thus
    * the null terminator is redundant, but it is required by the BSON
    * specification.
+   *
+   * +str+ must either already be in UTF-8 encoding or be a string encodable
+   * to UTF-8. In particular, a string in BINARY/ASCII-8BIT encoding is
+   * generally not suitable for this method. +EncodingError+ will be raised
+   * if +str+ cannot be encoded in UTF-8, or if +str+ claims to be encoded in
+   * UTF-8 but contains bytes/byte sequences which are not valid in UTF-8.
+   * Use #put_bytes to write arbitrary byte strings to the buffer.
    *
    * Returns the modified +self+.
    */

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -136,12 +136,15 @@ void Init_bson_native()
    *   buffer.put_cstring(obj) -> ByteBuffer
    *
    * Converts +obj+ to a string, which must not contain any null bytes, and
-   * which must be valid UTF-8, and writes the string to the buffer.
-   * +obj+ can be an instance of String, Symbol or Fixnum.
+   * which must be valid UTF-8, and writes the string to the buffer as a
+   * BSON cstring. +obj+ can be an instance of String, Symbol or Fixnum.
    *
    * If the string serialization of +obj+ contains null bytes, this method
    * raises +ArgumentError+. If +obj+ is of an unsupported type, this method
    * raises +TypeError+.
+   *
+   * BSON cstring serialization contains no length of the string (relying
+   * instead on the null terminator), unlike the BSON string serialization.
    */
   rb_define_method(rb_byte_buffer_class, "put_cstring", rb_bson_byte_buffer_put_cstring, 1);
   

--- a/ext/bson/libbson-utf8.c
+++ b/ext/bson/libbson-utf8.c
@@ -122,14 +122,14 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
        * Ensure we have a valid multi-byte sequence length.
        */
       if (!seq_length) {
-         rb_raise(rb_eArgError, "String %s is not valid UTF-8: bogus initial bits", utf8);
+         rb_raise(rb_eEncodingError, "String %s is not valid UTF-8: bogus initial bits", utf8);
       }
 
       /*
        * Ensure we have enough bytes left.
        */
       if ((utf8_len - i) < seq_length) {
-         rb_raise(rb_eArgError, "String %s is not valid UTF-8: truncated multi-byte sequence", utf8);
+         rb_raise(rb_eEncodingError, "String %s is not valid UTF-8: truncated multi-byte sequence", utf8);
       }
 
       /*
@@ -144,7 +144,7 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
       for (j = i + 1; j < (i + seq_length); j++) {
          c = (c << 6) | (utf8[j] & 0x3F);
          if ((utf8[j] & 0xC0) != 0x80) {
-            rb_raise(rb_eArgError, "String %s is not valid UTF-8: bogus high bits for continuation byte", utf8);
+            rb_raise(rb_eEncodingError, "String %s is not valid UTF-8: bogus high bits for continuation byte", utf8);
          }
       }
 
@@ -168,7 +168,7 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
        * Code point won't fit in utf-16, not allowed.
        */
       if (c > 0x0010FFFF) {
-         rb_raise(rb_eArgError, "String %s is not valid UTF-8: code point %"PRIu32" does not fit in UTF-16", utf8, c);
+         rb_raise(rb_eEncodingError, "String %s is not valid UTF-8: code point %"PRIu32" does not fit in UTF-16", utf8, c);
       }
 
       /*
@@ -176,7 +176,7 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
        * for surrogate pairs.
        */
       if ((c & 0xFFFFF800) == 0xD800) {
-         rb_raise(rb_eArgError, "String %s is not valid UTF-8: byte is in surrogate pair reserved range", utf8);
+         rb_raise(rb_eEncodingError, "String %s is not valid UTF-8: byte is in surrogate pair reserved range", utf8);
       }
 
       /*
@@ -222,7 +222,7 @@ rb_bson_utf8_validate (const char *utf8, /* IN */
       }
       
       if (not_shortest_form) {
-        rb_raise(rb_eArgError, "String %s is not valid UTF-8: not in shortest form", utf8);
+        rb_raise(rb_eEncodingError, "String %s is not valid UTF-8: not in shortest form", utf8);
       }
    }
 }

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -189,9 +189,13 @@ VALUE pvt_bson_byte_buffer_put_binary_string(VALUE self, const char *str, int32_
   return self;
 }
 
-/* The docstring is in init.c. */
-VALUE rb_bson_byte_buffer_put_string(VALUE self, VALUE string)
-{
+/**
+ * Encodes +string+ to UTF-8. If +string+ is already in UTF-8, validates that
+ * it contains only valid UTF-8 bytes/byte sequences.
+ *
+ * Raises EncodingError on failure.
+ */
+static VALUE pvt_bson_encode_to_utf8(VALUE string) {
   VALUE existing_encoding_name;
   VALUE encoding;
   VALUE utf8_string;
@@ -204,11 +208,29 @@ VALUE rb_bson_byte_buffer_put_string(VALUE self, VALUE string)
   
   if (strcmp(RSTRING_PTR(existing_encoding_name), "UTF-8") == 0) {
     utf8_string = string;
+  
+    str = RSTRING_PTR(utf8_string);
+    length = RSTRING_LEN(utf8_string);
+    
+    rb_bson_utf8_validate(str, length, true);
   } else {
     encoding = rb_enc_str_new_cstr("UTF-8", rb_utf8_encoding());
     utf8_string = rb_funcall(string, rb_intern("encode"), 1, encoding);
     RB_GC_GUARD(encoding);
   }
+  
+  return utf8_string;
+}
+
+/* The docstring is in init.c. */
+VALUE rb_bson_byte_buffer_put_string(VALUE self, VALUE string)
+{
+  VALUE utf8_string;
+  const char *str;
+  int32_t length;
+  
+  utf8_string = pvt_bson_encode_to_utf8(string);
+  /* At this point utf8_string contains valid utf-8 byte sequences only */
   
   str = RSTRING_PTR(utf8_string);
   length = RSTRING_LEN(utf8_string);
@@ -242,7 +264,7 @@ VALUE rb_bson_byte_buffer_put_cstring(VALUE self, VALUE obj)
 
   switch (TYPE(obj)) {
   case T_STRING:
-    string = obj;
+    string = pvt_bson_encode_to_utf8(obj);
     break;
   case T_SYMBOL:
     string = rb_sym2str(obj);

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -15,6 +15,7 @@
  */
 
 #include "bson-native.h"
+#include <ruby/encoding.h>
 
 typedef struct{
   byte_buffer_t *b;
@@ -191,9 +192,14 @@ VALUE pvt_bson_byte_buffer_put_binary_string(VALUE self, const char *str, int32_
 /* The docstring is in init.c. */
 VALUE rb_bson_byte_buffer_put_string(VALUE self, VALUE string)
 {
-  const char *str = RSTRING_PTR(string);
-  const int32_t length = RSTRING_LEN(string);
+  VALUE encoding = rb_enc_str_new_cstr("UTF-8", rb_utf8_encoding());
+  VALUE utf8_string = rb_funcall(string, rb_intern("encode"), 1, encoding);
+  const char *str = RSTRING_PTR(utf8_string);
+  const int32_t length = RSTRING_LEN(utf8_string);
 
+  RB_GC_GUARD(encoding);
+  RB_GC_GUARD(utf8_string);
+  
   return pvt_bson_byte_buffer_put_binary_string(self, str, length);
 }
 

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -218,7 +218,7 @@ describe BSON::ByteBuffer do
         expect(string.encoding.name).to eq('UTF-8')
       end
 
-      it 'raises ArgumentError' do
+      it 'raises EncodingError' do
         # Precise exception classes and messages differ between MRI and JRuby
         expect do
           modified
@@ -420,10 +420,11 @@ describe BSON::ByteBuffer do
         buffer.put_symbol(symbol)
       end
 
-      it 'raises ArgumentError' do
+      it 'raises EncodingError' do
+        # Precise exception classes and messages differ between MRI and JRuby
         expect do
           modified
-        end.to raise_error(EncodingError, /String.*is not valid UTF-8: bogus initial bits/)
+        end.to raise_error(EncodingError)
       end
     end
   end

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -219,9 +219,10 @@ describe BSON::ByteBuffer do
       end
 
       it 'raises ArgumentError' do
+        # Precise exception classes and messages differ between MRI and JRuby
         expect do
           modified
-        end.to raise_error(ArgumentError, /String.*is not valid UTF-8: bogus initial bits/)
+        end.to raise_error(EncodingError)
       end
     end
 
@@ -422,7 +423,7 @@ describe BSON::ByteBuffer do
       it 'raises ArgumentError' do
         expect do
           modified
-        end.to raise_error(ArgumentError, /String.*is not valid UTF-8: bogus initial bits/)
+        end.to raise_error(EncodingError, /String.*is not valid UTF-8: bogus initial bits/)
       end
     end
   end

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -247,6 +247,7 @@ describe BSON::ByteBuffer do
 
     context 'when string is in an encoding other than utf-8' do
       let(:string) do
+        # "\xfe"
         Utils.make_byte_string([254], 'iso-8859-1')
       end
 
@@ -254,9 +255,13 @@ describe BSON::ByteBuffer do
         buffer.put_string(string)
       end
 
-      it 'is written as utf-8' do
+      let(:expected) do
         # \xc3\xbe == \u00fe
-        expect(modified.to_s).to eq("\x03\x00\x00\x00\xc3\xbe\x00".force_encoding('binary'))
+        Utils.make_byte_string([3, 0, 0, 0, 0xc3, 0xbe, 0])
+      end
+
+      it 'is written as utf-8' do
+        expect(modified.to_s).to eq(expected)
       end
     end
   end

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -65,6 +65,20 @@ describe BSON::ByteBuffer do
 
       it_behaves_like 'does not write'
     end
+
+    context 'when byte is not valid utf-8' do
+      let(:string) do
+        Utils.make_byte_string([254]).freeze
+      end
+
+      let(:modified) do
+        buffer.put_byte(string)
+      end
+
+      it 'writes the byte' do
+        expect(modified.to_s).to eq(string)
+      end
+    end
   end
 
   describe '#put_bytes' do
@@ -104,6 +118,20 @@ describe BSON::ByteBuffer do
 
       it 'writes the string' do
         expect(modified.write_position).to eq(4)
+      end
+    end
+
+    context 'when bytes are not valid utf-8' do
+      let(:string) do
+        Utils.make_byte_string([254, 0, 255]).freeze
+      end
+
+      let(:modified) do
+        buffer.put_bytes(string)
+      end
+
+      it 'writes the bytes' do
+        expect(modified.to_s).to eq(string)
       end
     end
   end
@@ -174,6 +202,22 @@ describe BSON::ByteBuffer do
 
       it 'writes length and null terminator' do
         expect(modified.write_position).to eq(5)
+      end
+    end
+
+    context 'when string is not valid utf-8' do
+      let(:string) do
+        Utils.make_byte_string([254, 0, 255])
+      end
+
+      let(:modified) do
+        buffer.put_string(string)
+      end
+
+      it 'raises ArgumentError' do
+        expect do
+          modified
+        end.to raise_error(ArgumentError, /String.*is not valid UTF-8: bogus initial bits/)
       end
     end
   end
@@ -319,6 +363,22 @@ describe BSON::ByteBuffer do
       it 'advances write position' do
         # 4 byte length + 5 byte string + null byte
         expect(modified.write_position).to eq(10)
+      end
+    end
+
+    context 'when symbol is not valid utf-8' do
+      let(:symbol) do
+        Utils.make_byte_string([254, 0, 255]).to_sym
+      end
+
+      let(:modified) do
+        buffer.put_symbol(symbol)
+      end
+
+      it 'raises ArgumentError' do
+        expect do
+          modified
+        end.to raise_error(ArgumentError, /String.*is not valid UTF-8: bogus initial bits/)
       end
     end
   end

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -1,0 +1,10 @@
+module Utils
+  # JRuby chokes when strings like "\xfe\x00\xff", which are not valid UTF-8,
+  # appear in the source. Use this method to build such strings.
+  # char_array is an array of byte values to use for the string.
+  module_function def make_byte_string(char_array)
+    char_array.map do |char|
+      char.chr.force_encoding('BINARY')
+    end.join
+  end
+end

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -2,9 +2,9 @@ module Utils
   # JRuby chokes when strings like "\xfe\x00\xff", which are not valid UTF-8,
   # appear in the source. Use this method to build such strings.
   # char_array is an array of byte values to use for the string.
-  module_function def make_byte_string(char_array)
+  module_function def make_byte_string(char_array, encoding = 'BINARY')
     char_array.map do |char|
       char.chr.force_encoding('BINARY')
-    end.join
+    end.join.force_encoding(encoding)
   end
 end

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -431,8 +431,8 @@ public class ByteBuf extends RubyObject {
       string = (RubyString) value;
     }
     string = convertToUtf8(context, string);
-    verifyNoNulls(string);
     String javaString = string.asJavaString();
+    verifyNoNulls(javaString);
     this.writePosition += writeCharacters(javaString);
    } else {
     throw getRuntime().newTypeError(format("Invalid type for put_cstring: %s", value));
@@ -669,7 +669,7 @@ public class ByteBuf extends RubyObject {
     return encodedString;
   }
   
-  private void verifyNoNulls(RubyString string) {
+  private void verifyNoNulls(String string) {
     int len = string.length();
 
     for (int i = 0; i < len;) {

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -455,9 +455,9 @@ public class ByteBuf extends RubyObject {
    * @version 4.2.2
    */
   @JRubyMethod(name = "put_symbol")
-  public ByteBuf putSymbol(final IRubyObject value) throws UnsupportedEncodingException {
-    String string = ((RubySymbol) value).asJavaString();
-    return putJavaString(string);
+  public ByteBuf putSymbol(ThreadContext context, final IRubyObject value) throws UnsupportedEncodingException {
+    RubyString str = (RubyString) ((RubySymbol) value).to_s(context);
+    return putString(context, str);
   }
 
   /**

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -398,9 +398,12 @@ public class ByteBuf extends RubyObject {
    * @version 4.0.0
    */
   @JRubyMethod(name = "put_string")
-  public ByteBuf putString(final IRubyObject value) throws UnsupportedEncodingException {
-    String string = ((RubyString) value).asJavaString();
-    return putJavaString(string);
+  public ByteBuf putString(ThreadContext context, final IRubyObject value) throws UnsupportedEncodingException {
+    RubyString string = (RubyString) value;
+    RubyString utf8 = RubyString.newString(getRuntime(), "UTF-8");
+    RubyString encodedString = (RubyString) string.encode(context, utf8);
+    String javaString = encodedString.asJavaString();
+    return putJavaString(javaString);
   }
 
   /**


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1978