### PR TITLE
RUBY-2046 Add BSON Binary Subtype 6 to list of binary subtypes

### DIFF
--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -39,6 +39,7 @@ module BSON
       :uuid_old => 3.chr,
       :uuid => 4.chr,
       :md5 => 5.chr,
+      :cyphertext => 6.chr,
       :user => 128.chr
     }.freeze
 

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -31,6 +31,12 @@ module BSON
 
     # The mappings of subtypes to their single byte identifiers.
     #
+    # @note subtype 6 (ciphertext) is used for the Client-Side Encryption
+    #   feature. Data represented by this subtype is often encrypted, but
+    #   may also be plaintext. All instances of this subtype necessary for
+    #   Client-Side Encryption will be created internally by the Ruby driver.
+    #   An application should not create new BSON::Binary objects of this subtype.
+    #
     # @since 2.0.0
     SUBTYPES = {
       :generic => 0.chr,
@@ -39,7 +45,7 @@ module BSON
       :uuid_old => 3.chr,
       :uuid => 4.chr,
       :md5 => 5.chr,
-      :cyphertext => 6.chr,
+      :ciphertext => 6.chr,
       :user => 128.chr
     }.freeze
 

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -204,7 +204,7 @@ describe BSON::Binary do
     end
 
     context "when the type is :cyphertext" do
-      let(:obj)  { described_class.new("testing", :cyphertext) }
+      let(:obj)  { described_class.new("testing", :ciphertext) }
       let(:bson) { "#{7.to_bson}#{6.chr}testing" }
 
       it_behaves_like "a serializable bson element"

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -203,6 +203,14 @@ describe BSON::Binary do
       it_behaves_like "a deserializable bson element"
     end
 
+    context "when the type is :cyphertext" do
+      let(:obj)  { described_class.new("testing", :cyphertext) }
+      let(:bson) { "#{7.to_bson}#{6.chr}testing" }
+
+      it_behaves_like "a serializable bson element"
+      it_behaves_like "a deserializable bson element"
+    end
+
     context 'when given binary string' do
       let(:obj) { described_class.new("\x00\xfe\xff".force_encoding('BINARY')) }
       let(:bson) { "#{3.to_bson}#{0.chr}\x00\xfe\xff".force_encoding('BINARY') }


### PR DESCRIPTION
Specification is [here](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/subtype6.rst).

This subtype is used to communicate with mongocryptd and store encrypted values in MongoDB.

(Not sure if there's anything more I need to do here.)