### PR TITLE
RUBY-2092 Fix build on Mingw and add Windows-CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+init:
+  - SET PATH=C:/Ruby%ruby_version%/bin;%PATH%
+  - SET RAKEOPT=-rdevkit
+install:
+  - ps: |
+      if ($env:ruby_version -like "*head*") {
+        $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-$env:ruby_version.exe", "$pwd/ruby-setup.exe")
+        cmd /c ruby-setup.exe /verysilent /dir=C:/Ruby$env:ruby_version
+      }
+  - ruby --version
+  - gem --version
+  - gem install bundler --conservative
+  - bundle install
+build_script:
+  - bundle exec rake compile
+test_script:
+  - bundle exec rake spec
+environment:
+  matrix:
+    - ruby_version: "head-x64"
+    - ruby_version: "24"
+    - ruby_version: "26-x64"

--- a/ext/bson/bson-native.h
+++ b/ext/bson/bson-native.h
@@ -16,6 +16,7 @@
 
 #include <ruby.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <time.h>
 #include "bson-endian.h"

--- a/ext/bson/endian.c
+++ b/ext/bson/endian.c
@@ -15,6 +15,7 @@
  */
 
 #include <string.h>
+#include <stdint.h>
 #include "bson-endian.h"
 
 /*


### PR DESCRIPTION
Original issue is: https://github.com/oneclick/rubyinstaller2/issues/167

See commit messages for description. The CI result looks like so: https://ci.appveyor.com/project/larskanis/bson-ruby

This github project has to be registered at https://ci.appveyor.com/projects/new , so that each `git push` triggers a CI build.