### PR TITLE
RUBY-2066 implement legacy serialization mode for int32 and int64 to be consistent with legacy modes for integer and float


### DIFF
--- a/lib/bson/int32.rb
+++ b/lib/bson/int32.rb
@@ -128,7 +128,7 @@ module BSON
     #
     # @return [ Hash | Integer ] The extended json representation.
     def as_extended_json(**options)
-      if options[:mode] == :relaxed
+      if options[:mode] == :relaxed || options[:mode] == :legacy
         value
       else
         {'$numberInt' => value.to_s}

--- a/lib/bson/int64.rb
+++ b/lib/bson/int64.rb
@@ -128,7 +128,7 @@ module BSON
     #
     # @return [ Hash | Integer ] The extended json representation.
     def as_extended_json(**options)
-      if options[:mode] == :relaxed
+      if options[:mode] == :relaxed || options[:mode] == :legacy
         value
       else
         {'$numberLong' => value.to_s}

--- a/spec/bson/float_spec.rb
+++ b/spec/bson/float_spec.rb
@@ -26,4 +26,40 @@ describe Float do
     it_behaves_like "a serializable bson element"
     it_behaves_like "a deserializable bson element"
   end
+
+  describe '#to_json' do
+    it 'returns float' do
+      42.0.to_json.should == '42.0'
+    end
+  end
+
+  describe '#as_extended_json' do
+    context 'canonical mode' do
+      it 'returns $numberDouble' do
+        42.0.as_extended_json.should == {'$numberDouble' => '42.0'}
+      end
+    end
+
+    context 'relaxed mode' do
+      let(:serialized) do
+        42.0.as_extended_json(mode: :relaxed)
+      end
+
+      it 'returns float' do
+        serialized.should be_a(Float)
+        serialized.should be_within(0.00001).of(42)
+      end
+    end
+
+    context 'legacy mode' do
+      let(:serialized) do
+        42.0.as_extended_json(mode: :legacy)
+      end
+
+      it 'returns float' do
+        serialized.should be_a(Float)
+        serialized.should be_within(0.00001).of(42)
+      end
+    end
+  end
 end

--- a/spec/bson/int32_spec.rb
+++ b/spec/bson/int32_spec.rb
@@ -253,4 +253,24 @@ describe BSON::Int32 do
       expect(obj.value).to eq(12345)
     end
   end
+
+  describe '#as_extended_json' do
+    context 'canonical mode' do
+      it 'returns $numberInt' do
+        described_class.new(42).as_extended_json.should == {'$numberInt' => '42'}
+      end
+    end
+
+    context 'relaxed mode' do
+      it 'returns integer' do
+        described_class.new(42).as_extended_json(mode: :relaxed).should == 42
+      end
+    end
+
+    context 'legacy mode' do
+      it 'returns integer' do
+        described_class.new(42).as_extended_json(mode: :legacy).should be 42
+      end
+    end
+  end
 end

--- a/spec/bson/int64_spec.rb
+++ b/spec/bson/int64_spec.rb
@@ -318,4 +318,23 @@ describe BSON::Int64 do
     end
   end
 
+  describe '#as_extended_json' do
+    context 'canonical mode' do
+      it 'returns $numberLong' do
+        described_class.new(42).as_extended_json.should == {'$numberLong' => '42'}
+      end
+    end
+
+    context 'relaxed mode' do
+      it 'returns integer' do
+        described_class.new(42).as_extended_json(mode: :relaxed).should == 42
+      end
+    end
+
+    context 'legacy mode' do
+      it 'returns integer' do
+        described_class.new(42).as_extended_json(mode: :legacy).should be 42
+      end
+    end
+  end
 end

--- a/spec/bson/integer_spec.rb
+++ b/spec/bson/integer_spec.rb
@@ -68,4 +68,30 @@ describe Integer do
       expect(obj.to_bson_key).to eq(encoded)
     end
   end
+
+  describe '#to_json' do
+    it 'returns integer' do
+      42.to_json.should == '42'
+    end
+  end
+
+  describe '#as_extended_json' do
+    context 'canonical mode' do
+      it 'returns $numberInt' do
+        42.as_extended_json.should == {'$numberInt' => '42'}
+      end
+    end
+
+    context 'relaxed mode' do
+      it 'returns integer' do
+        42.as_extended_json(mode: :relaxed).should be 42
+      end
+    end
+
+    context 'legacy mode' do
+      it 'returns integer' do
+        42.as_extended_json(mode: :legacy).should be 42
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-2066