### PR TITLE
RUBY-2145 fix typo in documentation - MongoDB time resolution is milliseconds


### DIFF
--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -559,7 +559,7 @@ Time Instances
 --------------
 
 Times in Ruby can have nanosecond precision. Times in BSON (and MongoDB)
-can only have microsecond precision. When Ruby ``Time`` instances are
+can only have millisecond precision. When Ruby ``Time`` instances are
 serialized to BSON or Extended JSON, the times are floored to the nearest
 millisecond.
 


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-2145