### PR TITLE
Read CC environment variable

### DIFF
--- a/ext/bson/extconf.rb
+++ b/ext/bson/extconf.rb
@@ -1,3 +1,4 @@
 require "mkmf"
 $CFLAGS << " -Wall -g -std=c99"
+RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 create_makefile("bson_native")


### PR DESCRIPTION
To allow compilation with non-gcc compilers

For reference, this is also what e.g. the sqlite rubygem does: https://github.com/sparklemotion/sqlite3-ruby/blob/master/ext/sqlite3/extconf.rb#L7