### PR TITLE
RUBY-2185 Fix compaction-related segfault

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -79,6 +79,7 @@ functions:
               export MACHINE="${MACHINE}"
               export CI=1
               export WITH_ACTIVE_SUPPORT="${WITH_ACTIVE_SUPPORT}"
+              export COMPACT="${COMPACT}"
            EOT
            # See what we've done
            cat expansion.yml
@@ -499,13 +500,13 @@ axes:
       #  run_on: rhel71-power8-test
       #  variables:
       #    MACHINE: "rhel71-ppc"
-      
+
       - id: "ubuntu1804-ppc"
         display_name: "Ubuntu 18.04 PowerPC"
         run_on: ubuntu1804-power8-test
         variables:
           MACHINE: ubuntu1804-ppc
-      
+
       - id: "ubuntu1604-arm"
         display_name: "Ubuntu 16.04 ARM64"
         run_on: ubuntu1604-arm64-small
@@ -555,6 +556,13 @@ axes:
         display_name: AS
         variables:
           WITH_ACTIVE_SUPPORT: true
+  - id: "compact"
+    display_name: GC.compact
+    values:
+      - id: "on"
+        display_name: with GC.compact
+        variables:
+          COMPACT: true
 
 buildvariants:
 - matrix_name: "mri-rhel"
@@ -590,8 +598,19 @@ buildvariants:
   display_name: "${ruby-head}, ${all-os}"
   tasks:
      - name: "test"
+
 - matrix_name: "jruby"
   matrix_spec: { jruby-rubies: "*", all-os: ["rhel70"] }
   display_name: "${jruby-rubies}, ${all-os}"
   tasks:
      - name: "test"
+
+- matrix_name: "compact"
+  matrix_spec:
+    mri-rubies: ["ruby-2.7"]
+    jruby-rubies: ["jruby-9.2"]
+    all-os: "ubuntu1404"
+    compact: "on"
+  display_name: "GC.compact"
+  tasks:
+    - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -608,9 +608,8 @@ buildvariants:
 - matrix_name: "compact"
   matrix_spec:
     mri-rubies: ["ruby-2.7"]
-    jruby-rubies: ["jruby-9.2"]
     all-os: "ubuntu1404"
     compact: "on"
-  display_name: "GC.compact"
+  display_name: "${mri-rubies} with GC.compact"
   tasks:
     - name: "test"

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -38,25 +38,26 @@ void Init_bson_native()
   char rb_bson_machine_id[256];
 
   VALUE rb_bson_module = rb_define_module("BSON");
-  
+
   /* Document-class: BSON::ByteBuffer
    *
    * Stores BSON-serialized data and provides efficient serialization and
    * deserialization of common Ruby classes using native code.
    */
   VALUE rb_byte_buffer_class = rb_define_class_under(rb_bson_module, "ByteBuffer", rb_cObject);
-  
+
   VALUE rb_bson_object_id_class = rb_const_get(rb_bson_module, rb_intern("ObjectId"));
   VALUE rb_bson_object_id_generator_class = rb_const_get(rb_bson_object_id_class, rb_intern("Generator"));
   VALUE rb_digest_class = rb_const_get(rb_cObject, rb_intern("Digest"));
   VALUE rb_md5_class = rb_const_get(rb_digest_class, rb_intern("MD5"));
 
   rb_bson_illegal_key = rb_const_get(rb_const_get(rb_bson_module, rb_intern("String")),rb_intern("IllegalKey"));
+  rb_gc_register_mark_object(rb_bson_illegal_key);
 
   rb_define_alloc_func(rb_byte_buffer_class, rb_bson_byte_buffer_allocate);
   rb_define_method(rb_byte_buffer_class, "initialize", rb_bson_byte_buffer_initialize, -1);
   rb_define_method(rb_byte_buffer_class, "length", rb_bson_byte_buffer_length, 0);
-  
+
   /*
    * call-seq:
    *   buffer.read_position -> Fixnum
@@ -64,13 +65,13 @@ void Init_bson_native()
    * Returns the read position in the buffer.
    */
   rb_define_method(rb_byte_buffer_class, "read_position", rb_bson_byte_buffer_read_position, 0);
-  
+
   rb_define_method(rb_byte_buffer_class, "get_byte", rb_bson_byte_buffer_get_byte, 0);
   rb_define_method(rb_byte_buffer_class, "get_bytes", rb_bson_byte_buffer_get_bytes, 1);
   rb_define_method(rb_byte_buffer_class, "get_cstring", rb_bson_byte_buffer_get_cstring, 0);
   rb_define_method(rb_byte_buffer_class, "get_decimal128_bytes", rb_bson_byte_buffer_get_decimal128_bytes, 0);
   rb_define_method(rb_byte_buffer_class, "get_double", rb_bson_byte_buffer_get_double, 0);
-  
+
   /*
    * call-seq:
    *   buffer.get_hash(**options) -> Hash
@@ -82,7 +83,7 @@ void Init_bson_native()
    * @return [ BSON::Document ] The decoded document.
    */
   rb_define_method(rb_byte_buffer_class, "get_hash", rb_bson_byte_buffer_get_hash, -1);
-  
+
   /*
    * call-seq:
    *   buffer.get_array(**options) -> Array
@@ -94,11 +95,11 @@ void Init_bson_native()
    * @return [ Array ] The decoded array.
    */
   rb_define_method(rb_byte_buffer_class, "get_array", rb_bson_byte_buffer_get_array, -1);
-  
+
   rb_define_method(rb_byte_buffer_class, "get_int32", rb_bson_byte_buffer_get_int32, 0);
   rb_define_method(rb_byte_buffer_class, "get_int64", rb_bson_byte_buffer_get_int64, 0);
   rb_define_method(rb_byte_buffer_class, "get_string", rb_bson_byte_buffer_get_string, 0);
-  
+
   /*
    * call-seq:
    *   buffer.write_position -> Fixnum
@@ -106,7 +107,7 @@ void Init_bson_native()
    * Returns the write position in the buffer.
    */
   rb_define_method(rb_byte_buffer_class, "write_position", rb_bson_byte_buffer_write_position, 0);
-  
+
   /*
    * call-seq:
    *   buffer.put_byte(binary_str) -> ByteBuffer
@@ -117,7 +118,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_byte", rb_bson_byte_buffer_put_byte, 1);
-  
+
   /*
    * call-seq:
    *   buffer.put_bytes(binary_str) -> ByteBuffer
@@ -170,7 +171,7 @@ void Init_bson_native()
    * instead on the null terminator), unlike the BSON string serialization.
    */
   rb_define_method(rb_byte_buffer_class, "put_cstring", rb_bson_byte_buffer_put_cstring, 1);
-  
+
   /**
    * call-seq:
    *   buffer.put_symbol(sym) -> ByteBuffer
@@ -188,7 +189,7 @@ void Init_bson_native()
    * indistinguishable from a string with the same value written to the buffer.
    */
   rb_define_method(rb_byte_buffer_class, "put_symbol", rb_bson_byte_buffer_put_symbol, 1);
-  
+
   /*
    * call-seq:
    *   buffer.put_int32(fixnum) -> ByteBuffer
@@ -200,7 +201,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_int32", rb_bson_byte_buffer_put_int32, 1);
-  
+
   /*
    * call-seq:
    *   buffer.put_int64(fixnum) -> ByteBuffer
@@ -212,7 +213,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_int64", rb_bson_byte_buffer_put_int64, 1);
-  
+
   /*
    * call-seq:
    *   buffer.put_double(double) -> ByteBuffer
@@ -222,7 +223,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_double", rb_bson_byte_buffer_put_double, 1);
-  
+
   /*
    * call-seq:
    *   buffer.put_decimal128(low_64bit, high_64bit) -> ByteBuffer
@@ -235,7 +236,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_decimal128", rb_bson_byte_buffer_put_decimal128, 2);
-  
+
   /*
    * call-seq:
    *   buffer.put_hash(hash) -> ByteBuffer
@@ -245,7 +246,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_hash", rb_bson_byte_buffer_put_hash, 2);
-  
+
   /*
    * call-seq:
    *   buffer.put_array(array) -> ByteBuffer
@@ -255,7 +256,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "put_array", rb_bson_byte_buffer_put_array, 2);
-  
+
   /*
    * call-seq:
    *   buffer.replace_int32(position, fixnum) -> ByteBuffer
@@ -272,7 +273,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "replace_int32", rb_bson_byte_buffer_replace_int32, 2);
-  
+
   /*
    * call-seq:
    *   buffer.rewind! -> ByteBuffer
@@ -284,7 +285,7 @@ void Init_bson_native()
    * Returns the modified +self+.
    */
   rb_define_method(rb_byte_buffer_class, "rewind!", rb_bson_byte_buffer_rewind, 0);
-  
+
   /*
    * call-seq:
    *   buffer.to_s -> String
@@ -296,7 +297,7 @@ void Init_bson_native()
    * the buffer itself.
    */
   rb_define_method(rb_byte_buffer_class, "to_s", rb_bson_byte_buffer_to_s, 0);
-  
+
   rb_define_method(rb_bson_object_id_generator_class, "next_object_id", rb_bson_object_id_generator_next, -1);
 
   // Get the object id machine id and hash it.
@@ -309,4 +310,5 @@ void Init_bson_native()
   rb_bson_object_id_counter = FIX2INT(rb_funcall(rb_mKernel, rb_intern("rand"), 1, INT2FIX(0x1000000)));
 
   rb_bson_registry = rb_const_get(rb_bson_module, rb_intern("Registry"));
+  rb_gc_register_mark_object(rb_bson_registry);
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,4 +60,15 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
   end
+
+  # To ensure that calling GC.compact does not produce unexpected behavior,
+  # randomly call GC.compact after a small percentage of tests in the suite.
+  # This behavior is only enabled when the COMPACT environment variable is true.
+  if SpecConfig.instance.compact?
+    config.after do
+      if rand < SpecConfig::COMPACTION_CHANCE
+        GC.compact
+      end
+    end
+  end
 end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -13,13 +13,3 @@ class SpecConfig
     %w(1 true yes).include?(ENV['COMPACT'])
   end
 end
-
-RSpec.configure do |config|
-  if SpecConfig.instance.compact?
-    config.after do
-      if rand < SpecConfig::COMPACTION_CHANCE
-        GC.compact
-      end
-    end
-  end
-end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -3,7 +3,23 @@ require 'singleton'
 class SpecConfig
   include Singleton
 
+  COMPACTION_CHANCE = 0.001
+
   def active_support?
     %w(1 true yes).include?(ENV['WITH_ACTIVE_SUPPORT'])
+  end
+
+  def compact?
+    %w(1 true yes).include?(ENV['COMPACT'])
+  end
+end
+
+RSpec.configure do |config|
+  if SpecConfig.instance.compact?
+    config.after do
+      if rand < SpecConfig::COMPACTION_CHANCE
+        GC.compact
+      end
+    end
   end
 end


### PR DESCRIPTION
When `GC.compact` is called while using the Ruby driver, the bson gem sometimes segfaults. This is because there are global variables in the bson C extension that are not properly marked during GC, causing their memory to sometimes be compacted and the C extension to find another object in their place, hence the segfaults.

This is fixed by calling `rb_gc_register_mark_object` and passing in the VALUEs -- this tells the C extension to mark those global variables as roots during GC, which prevents their values from being moved.

Question: should there be a test for this?