### PR TITLE
RUBY-2063 Changed Timestamps to allow for unsigned 64 bit integers

### DIFF
--- a/ext/bson/bson-native.h
+++ b/ext/bson/bson-native.h
@@ -86,6 +86,7 @@ VALUE rb_bson_byte_buffer_put_cstring(VALUE self, VALUE string);
 VALUE rb_bson_byte_buffer_put_decimal128(VALUE self, VALUE low, VALUE high);
 VALUE rb_bson_byte_buffer_put_double(VALUE self, VALUE f);
 VALUE rb_bson_byte_buffer_put_int32(VALUE self, VALUE i);
+VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i);
 VALUE rb_bson_byte_buffer_put_int64(VALUE self, VALUE i);
 VALUE rb_bson_byte_buffer_put_string(VALUE self, VALUE string);
 VALUE rb_bson_byte_buffer_put_symbol(VALUE self, VALUE symbol);

--- a/ext/bson/bson-native.h
+++ b/ext/bson/bson-native.h
@@ -76,6 +76,7 @@ VALUE rb_bson_byte_buffer_get_cstring(VALUE self);
 VALUE rb_bson_byte_buffer_get_decimal128_bytes(VALUE self);
 VALUE rb_bson_byte_buffer_get_double(VALUE self);
 VALUE rb_bson_byte_buffer_get_int32(VALUE self);
+VALUE rb_bson_byte_buffer_get_uint32(VALUE self);
 VALUE rb_bson_byte_buffer_get_int64(VALUE self);
 VALUE rb_bson_byte_buffer_get_string(VALUE self);
 VALUE rb_bson_byte_buffer_get_hash(int argc, VALUE *argv, VALUE self);

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -88,7 +88,7 @@ void Init_bson_native()
    * call-seq:
    *   buffer.get_array(**options) -> Array
    *
-   * Reads an array from the byte buffer..
+   * Reads an array from the byte buffer.
    *
    * @option options [ nil | :bson ] :mode Decoding mode to use.
    *
@@ -100,7 +100,7 @@ void Init_bson_native()
   
   /*
    * call-seq:
-   *   buffer.get_uint32(buffer) -> FixNum
+   *   buffer.get_uint32(buffer) -> Fixnum
    *
    * Reads an unsigned 32 bit number from the byte buffer.
    *

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -97,6 +97,7 @@ void Init_bson_native()
   rb_define_method(rb_byte_buffer_class, "get_array", rb_bson_byte_buffer_get_array, -1);
 
   rb_define_method(rb_byte_buffer_class, "get_int32", rb_bson_byte_buffer_get_int32, 0);
+  rb_define_method(rb_byte_buffer_class, "get_uint32", rb_bson_byte_buffer_get_uint32, 0);
   rb_define_method(rb_byte_buffer_class, "get_int64", rb_bson_byte_buffer_get_int64, 0);
   rb_define_method(rb_byte_buffer_class, "get_string", rb_bson_byte_buffer_get_string, 0);
 

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -97,6 +97,17 @@ void Init_bson_native()
   rb_define_method(rb_byte_buffer_class, "get_array", rb_bson_byte_buffer_get_array, -1);
 
   rb_define_method(rb_byte_buffer_class, "get_int32", rb_bson_byte_buffer_get_int32, 0);
+  
+  /*
+   * call-seq:
+   *   buffer.get_uint32(buffer) -> FixNum
+   *
+   * Reads an unsigned 32 bit number from the byte buffer..
+   *
+   * @return [ Fixnum ] The unsigned 32 bits integer from the buffer
+   *
+   * @api private
+   */
   rb_define_method(rb_byte_buffer_class, "get_uint32", rb_bson_byte_buffer_get_uint32, 0);
   rb_define_method(rb_byte_buffer_class, "get_int64", rb_bson_byte_buffer_get_int64, 0);
   rb_define_method(rb_byte_buffer_class, "get_string", rb_bson_byte_buffer_get_string, 0);

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -102,7 +102,7 @@ void Init_bson_native()
    * call-seq:
    *   buffer.get_uint32(buffer) -> FixNum
    *
-   * Reads an unsigned 32 bit number from the byte buffer..
+   * Reads an unsigned 32 bit number from the byte buffer.
    *
    * @return [ Fixnum ] The unsigned 32 bits integer from the buffer
    *

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -204,6 +204,18 @@ void Init_bson_native()
 
   /*
    * call-seq:
+   *   buffer.put_uint32(fixnum) -> ByteBuffer
+   *
+   * Writes an unsigned 32-bit integer value to the buffer.
+   *
+   * If the argument cannot be represented in 32 bits, raises RangeError.
+   *
+   * Returns the modified +self+.
+   */
+  rb_define_method(rb_byte_buffer_class, "put_uint32", rb_bson_byte_buffer_put_uint32, 1);
+
+  /*
+   * call-seq:
    *   buffer.put_int64(fixnum) -> ByteBuffer
    *
    * Writes a 64-bit integer value to the buffer.

--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -211,6 +211,9 @@ void Init_bson_native()
    * If the argument cannot be represented in 32 bits, raises RangeError.
    *
    * Returns the modified +self+.
+   *
+   * @api private
+   *
    */
   rb_define_method(rb_byte_buffer_class, "put_uint32", rb_bson_byte_buffer_put_uint32, 1);
 

--- a/ext/bson/read.c
+++ b/ext/bson/read.c
@@ -21,6 +21,7 @@ static void pvt_raise_decode_error(volatile VALUE msg);
 static int32_t pvt_validate_length(byte_buffer_t *b);
 static uint8_t pvt_get_type_byte(byte_buffer_t *b);
 static VALUE pvt_get_int32(byte_buffer_t *b);
+static VALUE pvt_get_uint32(byte_buffer_t *b);
 static VALUE pvt_get_int64(byte_buffer_t *b, int argc, VALUE *argv);
 static VALUE pvt_get_double(byte_buffer_t *b);
 static VALUE pvt_get_string(byte_buffer_t *b, const char *data_type);
@@ -258,6 +259,28 @@ VALUE pvt_get_int32(byte_buffer_t *b)
   b->read_position += 4;
   return INT2NUM(BSON_UINT32_FROM_LE(i32));
 }
+
+/**
+ * Get an unsigned int32 from the buffer.
+ */
+VALUE rb_bson_byte_buffer_get_uint32(VALUE self)
+{
+  byte_buffer_t *b;
+
+  TypedData_Get_Struct(self, byte_buffer_t, &rb_byte_buffer_data_type, b);
+  return pvt_get_uint32(b);
+}
+
+VALUE pvt_get_uint32(byte_buffer_t *b)
+{
+  uint32_t i32;
+
+  ENSURE_BSON_READ(b, 4);
+  memcpy(&i32, READ_PTR(b), 4);
+  b->read_position += 4;
+  return UINT2NUM(BSON_UINT32_FROM_LE(i32));
+}
+
 
 /**
  * Get a int64 from the buffer.

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -396,7 +396,7 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
   }
 
   temp = NUM2LL(i);
-  if (temp < 0 || temp >= pow(2, 32)) {
+  if (temp < 0 || temp > UINT32_MAX) {
     rb_raise(rb_eRangeError, "Number %lld is out of range [0, 2^32)", (long long)temp);
   }
 

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -392,7 +392,7 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
   uint32_t i32;
 
   if (RB_TYPE_P(i, T_FLOAT)) {
-    rb_raise(rb_eArgError, "put_uint32; incorrect type: float, expected: integer");
+    rb_raise(rb_eArgError, "put_uint32: incorrect type: float, expected: integer");
   }
 
   temp = NUM2LL(i);

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -392,6 +392,9 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
   if (RB_TYPE_P(i, T_FLOAT))
     rb_raise(rb_eArgError, "put_uint32; incorrect type: float, expected: integer");
 
+  if (NUM2LONG(i) < 0) {
+    rb_raise(rb_eRangeError, "put_uint32; inputted number cannot be less than 0");
+  }
 
   const uint32_t i32 = NUM2UINT(i);
 

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -395,7 +395,7 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
 
   int64_t temp = NUM2LL(i);
   if (temp < 0 || temp >= pow(2, 32)) {
-    rb_raise(rb_eRangeError, "Number %ld is out of range [0, 2^32)", (long)temp);
+    rb_raise(rb_eRangeError, "Number %lld is out of range [0, 2^32)", (long long)temp);
   }
 
   const uint32_t i32 = NUM2UINT(i);

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -392,7 +392,7 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
   if (RB_TYPE_P(i, T_FLOAT))
     rb_raise(rb_eArgError, "put_uint32; incorrect type: float, expected: integer");
 
-  if (NUM2LONG(i) < 0) {
+  if (NUM2LL(i) < 0) {
     rb_raise(rb_eRangeError, "put_uint32; inputted number cannot be less than 0");
   }
 

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -389,11 +389,13 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
 {
   byte_buffer_t *b;
 
-  if (RB_TYPE_P(i, T_FLOAT))
+  if (RB_TYPE_P(i, T_FLOAT)) {
     rb_raise(rb_eArgError, "put_uint32; incorrect type: float, expected: integer");
+  }
 
-  if (NUM2LL(i) < 0) {
-    rb_raise(rb_eRangeError, "put_uint32; inputted number cannot be less than 0");
+  int64_t temp = NUM2LL(i);
+  if (temp < 0 || temp >= pow(2, 32)) {
+    rb_raise(rb_eRangeError, "Number %ld is out of range [0, 2^32)", temp);
   }
 
   const uint32_t i32 = NUM2UINT(i);

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -388,6 +388,11 @@ void pvt_put_int32(byte_buffer_t *b, const int32_t i)
 VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
 {
   byte_buffer_t *b;
+
+  if (RB_TYPE_P(i, T_FLOAT))
+    rb_raise(rb_eArgError, "put_uint32; incorrect type: float, expected: integer");
+
+
   const uint32_t i32 = NUM2UINT(i);
 
   TypedData_Get_Struct(self, byte_buffer_t, &rb_byte_buffer_data_type, b);

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -388,17 +388,19 @@ void pvt_put_int32(byte_buffer_t *b, const int32_t i)
 VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
 {
   byte_buffer_t *b;
+  int64_t temp;
+  uint32_t i32;
 
   if (RB_TYPE_P(i, T_FLOAT)) {
     rb_raise(rb_eArgError, "put_uint32; incorrect type: float, expected: integer");
   }
 
-  int64_t temp = NUM2LL(i);
+  temp = NUM2LL(i);
   if (temp < 0 || temp >= pow(2, 32)) {
     rb_raise(rb_eRangeError, "Number %lld is out of range [0, 2^32)", (long long)temp);
   }
 
-  const uint32_t i32 = NUM2UINT(i);
+  i32 = NUM2UINT(i);
 
   TypedData_Get_Struct(self, byte_buffer_t, &rb_byte_buffer_data_type, b);
   pvt_put_uint32(b, i32);

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -27,6 +27,7 @@ static void pvt_replace_int32(byte_buffer_t *b, int32_t position, int32_t newval
 static void pvt_put_field(byte_buffer_t *b, VALUE rb_buffer, VALUE val, VALUE validating_keys);
 static void pvt_put_byte(byte_buffer_t *b, const char byte);
 static void pvt_put_int32(byte_buffer_t *b, const int32_t i32);
+static void pvt_put_uint32(byte_buffer_t *b, const uint32_t i32);
 static void pvt_put_int64(byte_buffer_t *b, const int64_t i);
 static void pvt_put_double(byte_buffer_t *b, double f);
 static void pvt_put_cstring(byte_buffer_t *b, const char *str, int32_t length, const char *data_type);
@@ -378,6 +379,25 @@ VALUE rb_bson_byte_buffer_put_int32(VALUE self, VALUE i)
 void pvt_put_int32(byte_buffer_t *b, const int32_t i)
 {
   const int32_t i32 = BSON_UINT32_TO_LE(i);
+  ENSURE_BSON_WRITE(b, 4);
+  memcpy(WRITE_PTR(b), &i32, 4);
+  b->write_position += 4;
+}
+
+/* The docstring is in init.c. */
+VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
+{
+  byte_buffer_t *b;
+  const uint32_t i32 = NUM2UINT(i);
+
+  TypedData_Get_Struct(self, byte_buffer_t, &rb_byte_buffer_data_type, b);
+  pvt_put_uint32(b, i32);
+  return self;
+}
+
+void pvt_put_uint32(byte_buffer_t *b, const uint32_t i)
+{
+  const uint32_t i32 = BSON_UINT32_TO_LE(i);
   ENSURE_BSON_WRITE(b, 4);
   memcpy(WRITE_PTR(b), &i32, 4);
   b->write_position += 4;

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -395,7 +395,7 @@ VALUE rb_bson_byte_buffer_put_uint32(VALUE self, VALUE i)
 
   int64_t temp = NUM2LL(i);
   if (temp < 0 || temp >= pow(2, 32)) {
-    rb_raise(rb_eRangeError, "Number %ld is out of range [0, 2^32)", temp);
+    rb_raise(rb_eRangeError, "Number %ld is out of range [0, 2^32)", (long)temp);
   }
 
   const uint32_t i32 = NUM2UINT(i);

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -110,6 +110,8 @@ module BSON
     #
     # @since 2.0.0
     def initialize(seconds, increment)
+      if seconds < 0 then seconds += 2**32 end
+      if increment < 0 then increment += 2**32 end
       @seconds, @increment = seconds, increment
     end
 
@@ -124,8 +126,8 @@ module BSON
     #
     # @since 2.0.0
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
-      buffer.put_int32(increment)
-      buffer.put_int32(seconds)
+      buffer.put_uint32(increment)
+      buffer.put_uint32(seconds)
     end
 
     # Deserialize timestamp from BSON.

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -110,8 +110,6 @@ module BSON
     #
     # @since 2.0.0
     def initialize(seconds, increment)
-      if seconds < 0 then seconds += 2**32 end
-      if increment < 0 then increment += 2**32 end
       @seconds, @increment = seconds, increment
     end
 
@@ -142,8 +140,8 @@ module BSON
     #
     # @since 2.0.0
     def self.from_bson(buffer, **options)
-      increment = buffer.get_int32
-      seconds = buffer.get_int32
+      increment = buffer.get_uint32
+      seconds = buffer.get_uint32
       new(seconds, increment)
     end
 

--- a/spec/bson/byte_buffer_read_spec.rb
+++ b/spec/bson/byte_buffer_read_spec.rb
@@ -66,7 +66,7 @@ describe BSON::ByteBuffer do
   describe '#get_double' do
 
     let(:buffer) do
-      described_class.new("#{12.5.to_bson.to_s}")
+      described_class.new(12.5.to_bson.to_s)
     end
 
     let!(:double) do
@@ -85,7 +85,7 @@ describe BSON::ByteBuffer do
   describe '#get_int32' do
 
     let(:buffer) do
-      described_class.new("#{12.to_bson.to_s}")
+      described_class.new(12.to_bson.to_s)
     end
 
     let!(:int32) do
@@ -104,7 +104,7 @@ describe BSON::ByteBuffer do
   describe '#get_uint32' do
 
     let(:buffer) do
-      described_class.new("#{4294967295.to_bson.to_s}")
+      described_class.new(4294967295.to_bson.to_s)
     end
 
     let!(:int32) do
@@ -123,7 +123,7 @@ describe BSON::ByteBuffer do
   describe '#get_int64' do
 
     let(:buffer) do
-      described_class.new("#{(Integer::MAX_64BIT - 1).to_bson.to_s}")
+      described_class.new((Integer::MAX_64BIT - 1).to_bson.to_s)
     end
 
     let!(:int64) do

--- a/spec/bson/byte_buffer_read_spec.rb
+++ b/spec/bson/byte_buffer_read_spec.rb
@@ -102,22 +102,43 @@ describe BSON::ByteBuffer do
   end
 
   describe '#get_uint32' do
+    context 'when using the 2^32-1' do
+      let(:buffer) do
+        described_class.new(4294967295.to_bson.to_s)
+      end
 
-    let(:buffer) do
-      described_class.new(4294967295.to_bson.to_s)
-    end
+      let!(:int32) do
+        buffer.get_uint32
+      end
 
-    let!(:int32) do
-      buffer.get_uint32
-    end
+      it 'gets the uint32 from the buffer' do
+        expect(int32).to eq(4294967295)
+      end
 
-    it 'gets the uint32 from the buffer' do
-      expect(int32).to eq(4294967295)
-    end
+      it 'increments the position by 4' do
+        expect(buffer.read_position).to eq(4)
+      end
+    
+    context 'when using the 2^32-2' do
+      let(:buffer) do
+        described_class.new(4294967294.to_bson.to_s)
+      end
 
-    it 'increments the position by 4' do
-      expect(buffer.read_position).to eq(4)
+      let!(:int32) do
+        buffer.get_uint32
+      end
+
+      it 'gets the uint32 from the buffer' do
+        expect(int32).to eq(4294967294)
+      end
+
+      it 'increments the position by 4' do
+        expect(buffer.read_position).to eq(4)
+      end
+      
     end
+  end
+
   end
 
   describe '#get_int64' do

--- a/spec/bson/byte_buffer_read_spec.rb
+++ b/spec/bson/byte_buffer_read_spec.rb
@@ -118,6 +118,7 @@ describe BSON::ByteBuffer do
       it 'increments the position by 4' do
         expect(buffer.read_position).to eq(4)
       end
+    end
     
     context 'when using 2^32-2' do
       let(:buffer) do
@@ -154,8 +155,6 @@ describe BSON::ByteBuffer do
         expect(buffer.read_position).to eq(4)
       end
     end
-  end
-
   end
 
   describe '#get_int64' do

--- a/spec/bson/byte_buffer_read_spec.rb
+++ b/spec/bson/byte_buffer_read_spec.rb
@@ -101,6 +101,25 @@ describe BSON::ByteBuffer do
     end
   end
 
+  describe '#get_uint32' do
+
+    let(:buffer) do
+      described_class.new("#{4294967295.to_bson.to_s}")
+    end
+
+    let!(:int32) do
+      buffer.get_uint32
+    end
+
+    it 'gets the uint32 from the buffer' do
+      expect(int32).to eq(4294967295)
+    end
+
+    it 'increments the position by 4' do
+      expect(buffer.read_position).to eq(4)
+    end
+  end
+
   describe '#get_int64' do
 
     let(:buffer) do

--- a/spec/bson/byte_buffer_read_spec.rb
+++ b/spec/bson/byte_buffer_read_spec.rb
@@ -102,7 +102,7 @@ describe BSON::ByteBuffer do
   end
 
   describe '#get_uint32' do
-    context 'when using the 2^32-1' do
+    context 'when using 2^32-1' do
       let(:buffer) do
         described_class.new(4294967295.to_bson.to_s)
       end
@@ -119,7 +119,7 @@ describe BSON::ByteBuffer do
         expect(buffer.read_position).to eq(4)
       end
     
-    context 'when using the 2^32-2' do
+    context 'when using 2^32-2' do
       let(:buffer) do
         described_class.new(4294967294.to_bson.to_s)
       end
@@ -135,7 +135,24 @@ describe BSON::ByteBuffer do
       it 'increments the position by 4' do
         expect(buffer.read_position).to eq(4)
       end
-      
+    end
+
+    context 'when using 0' do
+      let(:buffer) do
+        described_class.new(0.to_bson.to_s)
+      end
+
+      let!(:int32) do
+        buffer.get_uint32
+      end
+
+      it 'gets the uint32 from the buffer' do
+        expect(int32).to eq(0)
+      end
+
+      it 'increments the position by 4' do
+        expect(buffer.read_position).to eq(4)
+      end
     end
   end
 

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -51,9 +51,34 @@ describe BSON::ByteBuffer do
           end
         end
 
+        context 'when number doesn\'t fit in signed int32' do 
+          let(:modified) do
+            buffer.put_uint32(4294967295)
+          end
+
+          let(:expected) do
+            [ 4294967295 ].pack(BSON::Int32::PACK)
+          end
+
+          it 'appends the int32 to the byte buffer' do
+            expect(modified.to_s).to eq(expected)
+          end
+
+          it 'get returns correct number' do
+            expect(modified.get_uint32).to eq(4294967295)
+          end
+
+          it 'returns the length of the buffer' do
+            expect(modified.length).to eq(4)
+          end
+        end
+
         context 'when number is not in range' do 
-          it 'raises error on out of range number' do
+          it 'raises error on out of top range' do
             expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError)
+          end
+
+          it 'raises error on out of bottom range' do
             expect{ buffer.put_uint32(-4294967296) }.to raise_error(RangeError)
           end
         end

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -30,6 +30,7 @@ describe BSON::ByteBuffer do
       let(:buffer) do
         described_class.new
       end
+      
       context '#put_int32' do 
         before do
           buffer.put_int32(5)
@@ -79,7 +80,7 @@ describe BSON::ByteBuffer do
           end
 
           it 'raises error on out of bottom range' do
-            expect{ buffer.put_uint32(-4294967296) }.to raise_error(RangeError)
+            expect{ buffer.put_uint32(-1) }.to raise_error(RangeError)
           end
         end
       end

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -40,50 +40,6 @@ describe BSON::ByteBuffer do
           expect(buffer.length).to eq(4)
         end
       end
-
-      context '#put_uint32' do 
-        context 'when number is in range' do 
-          before do
-            buffer.put_uint32(5)
-          end
-
-          it 'returns the length of the buffer' do
-            expect(buffer.length).to eq(4)
-          end
-        end
-
-        context 'when number doesn\'t fit in signed int32' do 
-          let(:modified) do
-            buffer.put_uint32(4294967295)
-          end
-
-          let(:expected) do
-            [ 4294967295 ].pack(BSON::Int32::PACK)
-          end
-
-          it 'appends the int32 to the byte buffer' do
-            expect(modified.to_s).to eq(expected)
-          end
-
-          it 'get returns correct number' do
-            expect(modified.get_uint32).to eq(4294967295)
-          end
-
-          it 'returns the length of the buffer' do
-            expect(modified.length).to eq(4)
-          end
-        end
-
-        context 'when number is not in range' do 
-          it 'raises error on out of top range' do
-            expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError)
-          end
-
-          it 'raises error on out of bottom range' do
-            expect{ buffer.put_uint32(-1) }.to raise_error(RangeError)
-          end
-        end
-      end
     end
 
 

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -30,15 +30,36 @@ describe BSON::ByteBuffer do
       let(:buffer) do
         described_class.new
       end
+      context '#put_int32' do 
+        before do
+          buffer.put_int32(5)
+        end
 
-      before do
-        buffer.put_int32(5)
+        it 'returns the length of the buffer' do
+          expect(buffer.length).to eq(4)
+        end
       end
 
-      it 'returns the length of the buffer' do
-        expect(buffer.length).to eq(4)
+      context '#put_uint32' do 
+        context 'when number is in range' do 
+          before do
+            buffer.put_uint32(5)
+          end
+
+          it 'returns the length of the buffer' do
+            expect(buffer.length).to eq(4)
+          end
+        end
+
+        context 'when number is not in range' do 
+          it 'raises error on out of range number' do
+            expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError)
+            expect{ buffer.put_uint32(-4294967296) }.to raise_error(RangeError)
+          end
+        end
       end
     end
+
 
     context 'when the byte buffer is initialized with some bytes' do
 

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -590,7 +590,66 @@ describe BSON::ByteBuffer do
       it 'appends the int32 to the byte buffer' do
         expect{ buffer.put_uint32(4.934) }.to raise_error(ArgumentError, "put_uint32; incorrect type: float, expected: integer")
       end
+    end
+    
+    context 'when number is in range' do 
+      let(:modified) do
+        buffer.put_uint32(5)
+      end
 
+      it 'returns gets the correct number from the buffer' do
+        expect(modified.get_uint32).to eq(5)
+      end
+
+      it 'returns the length of the buffer' do
+        expect(modified.length).to eq(4)
+      end
+    end
+
+    context 'when number is 0' do 
+      let(:modified) do
+        buffer.put_uint32(0)
+      end
+
+      it 'returns gets the correct number from the buffer' do
+        expect(modified.get_uint32).to eq(0)
+      end
+
+      it 'returns the length of the buffer' do
+        expect(modified.length).to eq(4)
+      end
+    end
+
+    context 'when number doesn\'t fit in signed int32' do 
+      let(:modified) do
+        buffer.put_uint32(4294967295)
+      end
+
+      let(:expected) do
+        [ 4294967295 ].pack(BSON::Int32::PACK)
+      end
+
+      it 'appends the int32 to the byte buffer' do
+        expect(modified.to_s).to eq(expected)
+      end
+
+      it 'get returns correct number' do
+        expect(modified.get_uint32).to eq(4294967295)
+      end
+
+      it 'returns the length of the buffer' do
+        expect(modified.length).to eq(4)
+      end
+    end
+
+    context 'when number is not in range' do 
+      it 'raises error on out of top range' do
+        expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError)
+      end
+
+      it 'raises error on out of bottom range' do
+        expect{ buffer.put_uint32(-1) }.to raise_error(RangeError)
+      end
     end
   end
 

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -642,6 +642,34 @@ describe BSON::ByteBuffer do
       end
     end
 
+    context 'when number is 2^31' do 
+      let(:modified) do
+        buffer.put_uint32(2147483648)
+      end
+
+      it 'returns gets the correct number from the buffer' do
+        expect(modified.get_uint32).to eq(2147483648)
+      end
+
+      it 'returns the length of the buffer' do
+        expect(modified.length).to eq(4)
+      end
+    end
+
+    context 'when number is 2^31-1' do 
+      let(:modified) do
+        buffer.put_uint32(2147483647)
+      end
+
+      it 'returns gets the correct number from the buffer' do
+        expect(modified.get_uint32).to eq(2147483647)
+      end
+
+      it 'returns the length of the buffer' do
+        expect(modified.length).to eq(4)
+      end
+    end
+
     context 'when number is not in range' do 
       it 'raises error on out of top range' do
         expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError, "Number 4294967296 is out of range [0, 2^32)")

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -644,11 +644,11 @@ describe BSON::ByteBuffer do
 
     context 'when number is not in range' do 
       it 'raises error on out of top range' do
-        expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError)
+        expect{ buffer.put_uint32(4294967296) }.to raise_error(RangeError, "Number 4294967296 is out of range [0, 2^32)")
       end
 
       it 'raises error on out of bottom range' do
-        expect{ buffer.put_uint32(-1) }.to raise_error(RangeError)
+        expect{ buffer.put_uint32(-1) }.to raise_error(RangeError, "Number -1 is out of range [0, 2^32)")
       end
     end
   end

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -585,6 +585,15 @@ describe BSON::ByteBuffer do
     end
   end
 
+  describe '#put_uint32' do
+    context 'when argument is a float' do
+      it 'appends the int32 to the byte buffer' do
+        expect{ buffer.put_uint32(4.934) }.to raise_error(ArgumentError, "put_uint32; incorrect type: float, expected: integer")
+      end
+
+    end
+  end
+
   describe '#put_int64' do
 
     context 'when the integer is 64 bit' do

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -587,8 +587,8 @@ describe BSON::ByteBuffer do
 
   describe '#put_uint32' do
     context 'when argument is a float' do
-      it 'appends the int32 to the byte buffer' do
-        expect{ buffer.put_uint32(4.934) }.to raise_error(ArgumentError, "put_uint32; incorrect type: float, expected: integer")
+      it 'raises an Argument Error' do
+        expect{ buffer.put_uint32(4.934) }.to raise_error(ArgumentError, "put_uint32: incorrect type: float, expected: integer")
       end
     end
     

--- a/spec/spec_tests/data/corpus/timestamp.json
+++ b/spec/spec_tests/data/corpus/timestamp.json
@@ -13,6 +13,11 @@
             "canonical_bson": "100000001161002A00000015CD5B0700",
             "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 123456789, \"i\" : 42} } }",
             "degenerate_extjson": "{\"a\" : {\"$timestamp\" : {\"i\" : 42, \"t\" : 123456789} } }"
+        },
+        {
+            "description": "Timestamp with high-order bit set on both seconds and increment",
+            "canonical_bson": "10000000116100FFFFFFFFFFFFFFFF00",
+            "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4294967295, \"i\" :  4294967295} } }"
         }
     ],
     "decodeErrors": [

--- a/spec/spec_tests/data/corpus/timestamp.json
+++ b/spec/spec_tests/data/corpus/timestamp.json
@@ -16,6 +16,11 @@
         },
         {
             "description": "Timestamp with high-order bit set on both seconds and increment",
+            "canonical_bson": "10000000116100FFFFFFFFFFFFFFFF00",
+            "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4294967295, \"i\" :  4294967295} } }"
+        },
+        {
+            "description": "Timestamp with high-order bit set on both seconds and increment and not 2^32-1",
             "canonical_bson": "1000000011610000286BEE00286BEE00", 
             "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4000000000, \"i\" :  4000000000} } }"
         }

--- a/spec/spec_tests/data/corpus/timestamp.json
+++ b/spec/spec_tests/data/corpus/timestamp.json
@@ -16,8 +16,8 @@
         },
         {
             "description": "Timestamp with high-order bit set on both seconds and increment",
-            "canonical_bson": "10000000116100FFFFFFFFFFFFFFFF00",
-            "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4294967295, \"i\" :  4294967295} } }"
+            "canonical_bson": "1000000011610000286BEE00286BEE00", 
+            "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4000000000, \"i\" :  4000000000} } }"
         }
     ],
     "decodeErrors": [

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -102,7 +102,6 @@ public class ByteBuf extends RubyObject {
    * The size of an unsigned 32-bit integer: 2^32 - 1
    */
   private static long UINT32_MAX = 4294967295L;
-
   
   /**
    * Instantiate the ByteBuf - this is #allocate in Ruby.
@@ -529,7 +528,7 @@ public class ByteBuf extends RubyObject {
 
     long temp = RubyNumeric.fix2long((RubyFixnum) value);
     
-    if (temp > UINT32_MAX || temp < 0) { // TODO: change to UINT32_MAX
+    if (temp > UINT32_MAX || temp < 0) {
       throw getRuntime().newRangeError(format("Number %d is out of range [0, 2^32)", temp));
     }
 

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -515,7 +515,7 @@ public class ByteBuf extends RubyObject {
   @JRubyMethod(name = "put_uint32")
   public ByteBuf putUInt32(ThreadContext context, IRubyObject value) {
     if (value instanceof RubyFloat) {
-      throw getRuntime().newArgumentError("put_uint32; incorrect type: float, expected: integer");
+      throw getRuntime().newArgumentError("put_uint32: incorrect type: float, expected: integer");
     }
     ensureBsonWrite(4);
 

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -106,7 +106,7 @@ public class ByteBuf extends RubyObject {
   /**
    * The max of an signed 32-bit integer: 2^31
    */
-  private static long INT32_MAX = 2147483648L;
+  private static long INT32_MAX = 2147483647L;
   
   /**
    * Instantiate the ByteBuf - this is #allocate in Ruby.
@@ -535,7 +535,7 @@ public class ByteBuf extends RubyObject {
       throw getRuntime().newRangeError(format("Number %d is out of range [0, 2^32)", temp));
     }
     
-    if (temp > INT32_MAX) {
+    if (temp > INT32_MAX + 1) {
       temp -= UINT32_SIZE;
     }
 

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -99,6 +99,11 @@ public class ByteBuf extends RubyObject {
   private int writePosition = 0;
 
   /**
+   * The size of an unsigned 32-bit integer: 2^32
+   */
+  private static long UINT32_SIZE = (long)Math.pow(2, 32);
+  
+  /**
    * Instantiate the ByteBuf - this is #allocate in Ruby.
    *
    * @author Durran Jordan
@@ -316,7 +321,7 @@ public class ByteBuf extends RubyObject {
 
     long temp = this.buffer.getInt();
     if (temp < 0) {
-      temp += Math.pow(2, 32);
+      temp += UINT32_SIZE;
     }
     
     RubyFixnum int32 = new RubyFixnum(getRuntime(), temp);
@@ -521,12 +526,12 @@ public class ByteBuf extends RubyObject {
 
     long temp = RubyNumeric.fix2long((RubyFixnum) value);
     
-    if (temp >= Math.pow(2, 32) || temp < 0) {
+    if (temp >= UINT32_SIZE || temp < 0) {
       throw getRuntime().newRangeError(format("Number %d is out of range [0, 2^32)", temp));
     }
     
     if (temp > Math.pow(2, 31)) {
-      temp -= Math.pow(2, 32);
+      temp -= UINT32_SIZE;
     }
 
     this.buffer.putInt((int) temp);

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -101,7 +101,12 @@ public class ByteBuf extends RubyObject {
   /**
    * The size of an unsigned 32-bit integer: 2^32
    */
-  private static long UINT32_SIZE = (long)Math.pow(2, 32);
+  private static long UINT32_SIZE = 4294967296L;
+
+  /**
+   * The max of an signed 32-bit integer: 2^31
+   */
+  private static long INT32_MAX = 2147483648L;
   
   /**
    * Instantiate the ByteBuf - this is #allocate in Ruby.
@@ -530,7 +535,7 @@ public class ByteBuf extends RubyObject {
       throw getRuntime().newRangeError(format("Number %d is out of range [0, 2^32)", temp));
     }
     
-    if (temp > Math.pow(2, 31)) {
+    if (temp > INT32_MAX) {
       temp -= UINT32_SIZE;
     }
 

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -308,16 +308,16 @@ public class ByteBuf extends RubyObject {
 
   /**
    * Get a 32 bit integer from the buffer.
-   *
-   * @author Neil Shweky
-   * @since 2020.06.26
+   * 
    */
   @JRubyMethod(name = "get_uint32")
   public RubyFixnum getUInt32() {
     ensureBsonRead();
 
     long temp = this.buffer.getInt();
-    if (temp < 0) temp += Math.pow(2,32);
+    if (temp < 0) {
+      temp += Math.pow(2, 32);
+    }
     
     RubyFixnum int32 = new RubyFixnum(getRuntime(), temp);
     this.readPosition += 4;
@@ -510,25 +510,24 @@ public class ByteBuf extends RubyObject {
    * Put an unsigned 32 bit integer onto the buffer.
    *
    * @param value The integer to write.
-   *
-   * @author Neil Shweky
-   * @since 2020.06.26
+   * 
    */
   @JRubyMethod(name = "put_uint32")
   public ByteBuf putUInt32(ThreadContext context, IRubyObject value) {
     if (value instanceof RubyFloat) {
-      value = ((RubyFloat) value).truncate(context);
+      throw getRuntime().newArgumentError("put_uint32; incorrect type: float, expected: integer");
     }
     ensureBsonWrite(4);
 
     long temp = RubyNumeric.fix2long((RubyFixnum) value);
     
-    if (temp >= Math.pow(2, 32) || temp < 0)
+    if (temp >= Math.pow(2, 32) || temp < 0) {
       throw getRuntime().newRangeError(format("Number %d is out of range [0, 2^32)", temp));
+    }
     
-    if (temp > Math.pow(2,31)) temp -= Math.pow(2,32);
-
-
+    if (temp > Math.pow(2, 31)) {
+      temp -= Math.pow(2, 32);
+    }
 
     this.buffer.putInt((int) temp);
     this.writePosition += 4;


### PR DESCRIPTION
I did this by adding a new function to the C code called put_uint32 which allows for unsigned 32 bit integers. (You need two 32 bit integers, seconds and increment, which gives the above mentioned 64 bits)

I have not implemented the Java version yet.