### PR TITLE
RUBY-2307 Segmentation fault on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ git:
 
 before_install:
   - gem install bundler -v '<2'
-  - |
-    if [ "${COMMIT}" != "" ]; then
-      echo "Checking out ${COMMIT} ..."
-      git checkout "${COMMIT}"
-    fi
 
 rvm:
   - 2.3
@@ -23,20 +18,12 @@ jobs:
   include:
     - arch: s390x
       rvm: 2.7.1
-    - arch: s390x
-      rvm: 2.7.1
-      env:
-        - COMMIT=v4.9.0
-    - arch: s390x
-      rvm: 2.7.1
-      env:
-        - COMMIT=v4.8.2
 
 notifications:
   email: false
   flowdock: 1da4416b8ff98d1880986472428b1b1b
 
-# branches:
-#   only:
-#     - master
-#     - 5.0-dev
+branches:
+  only:
+    - master
+    - 5.0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,42 @@
 language: ruby
 
+git:
+  depth: false
+
 before_install:
   - gem install bundler -v '<2'
+  - |
+    if [ "${COMMIT}" != "" ]; then
+      echo "Checking out ${COMMIT} ..."
+      git checkout "${COMMIT}"
+    fi
 
 rvm:
   - 2.3
   - 2.7
 
-env: CI="travis"
+env:
+  global:
+    - CI="travis"
+
+jobs:
+  include:
+    - arch: s390x
+      rvm: 2.7.1
+    - arch: s390x
+      rvm: 2.7.1
+      env:
+        - COMMIT=v4.9.0
+    - arch: s390x
+      rvm: 2.7.1
+      env:
+        - COMMIT=v4.8.2
 
 notifications:
   email: false
   flowdock: 1da4416b8ff98d1880986472428b1b1b
 
-branches:
-  only:
-    - master
-    - 5.0-dev
+# branches:
+#   only:
+#     - master
+#     - 5.0-dev


### PR DESCRIPTION
This PR is to report the bug on s390x, bson >= 4.9.0, pointed by the JIRA ticket: [RUBY-2307](https://jira.mongodb.org/browse/RUBY-2307).

Adding some s390x cases for debugging.

Travis CI: https://travis-ci.org/github/mongodb/bson-ruby/builds/706149254

Thank you.

<hr />

Notes from @egiurleo:

I believe the issue is that the `pvt_get_string` method was using the wrong variable on big endian architectures when getting the int32 that represented the string length. It already declared a multi-purpose string length variable, so I just swapped out the little endian-specific variable for the one that works in both cases.