### PR TITLE
Fix RUBY-2128 JRuby ByteBuffer advances read & write positions together

### DIFF
--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -107,4 +107,20 @@ describe BSON::ByteBuffer do
       expect(buffer.write_position).to eq(1)
     end
   end
+
+  context "when doing reads/writes interrmittently" do
+
+    let(:buffer) do
+      described_class.new
+    end
+
+    it "gets the right values in order" do
+      buffer.put_int32(5)
+      buffer.put_int32(2)
+      expect(buffer.get_int32).to be(5)
+      buffer.put_int32(1)
+      expect(buffer.get_int32).to be(2)
+      expect(buffer.get_int32).to be(1)
+    end
+  end
 end

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -107,20 +107,4 @@ describe BSON::ByteBuffer do
       expect(buffer.write_position).to eq(1)
     end
   end
-
-  context "when doing reads/writes interrmittently" do
-
-    let(:buffer) do
-      described_class.new
-    end
-
-    it "gets the right values in order" do
-      buffer.put_int32(5)
-      buffer.put_int32(2)
-      expect(buffer.get_int32).to be(5)
-      buffer.put_int32(1)
-      expect(buffer.get_int32).to be(2)
-      expect(buffer.get_int32).to be(1)
-    end
-  end
 end

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -132,7 +132,9 @@ describe BSON::ByteBuffer do
 
     context 'mixed cycles' do
       it 'returns the written data' do
-        pending 'RUBY-2334'
+        if BSON::Environment.jruby?
+          pending 'RUBY-2334'
+        end
 
         buffer.put_int32(1)
         buffer.put_int32(2)

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -129,5 +129,21 @@ describe BSON::ByteBuffer do
         buffer.get_cstring.should == 'world'
       end
     end
+
+    context 'mixed cycles' do
+      it 'returns the written data' do
+        pending 'RUBY-2334'
+
+        buffer.put_int32(1)
+        buffer.put_int32(2)
+
+        buffer.get_int32.should == 1
+
+        buffer.put_int32(3)
+
+        buffer.get_int32.should == 2
+        buffer.get_int32.should == 3
+      end
+    end
   end
 end

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -30,8 +30,8 @@ describe BSON::ByteBuffer do
       let(:buffer) do
         described_class.new
       end
-      
-      context '#put_int32' do 
+
+      context '#put_int32' do
         before do
           buffer.put_int32(5)
         end
@@ -105,6 +105,29 @@ describe BSON::ByteBuffer do
       expect(buffer.write_position).to eq(1)
       buffer.rewind!
       expect(buffer.write_position).to eq(1)
+    end
+  end
+
+  describe 'write followed by read' do
+    let(:buffer) do
+      described_class.new
+    end
+
+    context 'one cycle' do
+      it 'returns the written data' do
+        buffer.put_cstring('hello')
+        buffer.get_cstring.should == 'hello'
+      end
+    end
+
+    context 'two cycles' do
+      it 'returns the written data' do
+        buffer.put_cstring('hello')
+        buffer.get_cstring.should == 'hello'
+
+        buffer.put_cstring('world')
+        buffer.get_cstring.should == 'world'
+      end
     end
   end
 end

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -244,6 +244,16 @@ describe Hash do
           /(Hash value for key 'foo'|Value) does not define its BSON serialized type:.*HashSpecUnserializableClass/)
       end
     end
+
+    context 'when hash is empty' do 
+      let(:buffer) do 
+        {}.to_bson
+      end
+
+      it 'has length 0' do 
+        expect(Hash.from_bson(buffer)).to eq({})
+      end
+    end
   end
 
   describe '#to_bson' do

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -250,7 +250,7 @@ describe Hash do
         {}.to_bson
       end
 
-      it 'has length 0' do 
+      it 'returns the empty hash when writing then reading from the buffer' do 
         expect(Hash.from_bson(buffer)).to eq({})
       end
     end

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -245,13 +245,13 @@ describe Hash do
       end
     end
 
-    context 'when hash is empty' do 
-      let(:buffer) do 
-        {}.to_bson
+    context 'when reading from a byte buffer that was previously written to' do
+      let(:buffer) do
+        {foo: 42}.to_bson
       end
 
-      it 'returns the empty hash when writing then reading from the buffer' do 
-        expect(Hash.from_bson(buffer)).to eq({})
+      it 'returns the original hash' do
+        expect(Hash.from_bson(buffer)).to eq('foo' => 42)
       end
     end
   end

--- a/src/main/org/bson/ByteBuf.java
+++ b/src/main/org/bson/ByteBuf.java
@@ -702,12 +702,14 @@ public class ByteBuf extends RubyObject {
   private void ensureBsonRead() {
     if (this.mode == Mode.WRITE) {
       this.buffer.flip();
+      this.mode = Mode.READ;
     }
   }
 
   private void ensureBsonWrite(int length) {
     if (this.mode == Mode.READ) {
       this.buffer.flip();
+      this.mode = mode.WRITE;
     }
     if (length > this.buffer.remaining()) {
       int size = (this.buffer.position() + length) * 2;


### PR DESCRIPTION
I did this by switching the mode on flipping the buffer.