### PR TITLE
RUBY-2397 Support parsing $uuid as extended JSON representation for subtype 4 binary

### DIFF
--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -137,6 +137,7 @@ module BSON
       if hash.empty?
         return {}
       end
+
       if hash.key?('$ref')
         # Legacy dbref handling.
         # Note that according to extended json spec, only hash values (but

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -221,11 +221,11 @@ module BSON
           create_binary(encoded_value, subtype)
 
         when '$uuid'
-          unless /\A[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\z/.match(hash['$uuid'])
-            raise Error::ExtJSONParseError, "Invalid $uuid value: #{hash}"
+          unless /\A[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\z/.match(value)
+            raise Error::ExtJSONParseError, "Invalid $uuid value: #{value}"
           end
 
-          return Binary.from_uuid(hash['$uuid'])
+          return Binary.from_uuid(value)
 
         when '$code'
           unless value.is_a?(String)

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -311,6 +311,8 @@ module BSON
           return create_binary(hash['$binary'], hash['$type'])
         end
 
+# TODO: add logic for $uuid
+
         if last_key == '$regex'
           unless sorted_keys == %w($options $regex)
             raise Error::ExtJSONParseError, "Invalid $regex value: #{hash}"

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -137,7 +137,6 @@ module BSON
       if hash.empty?
         return {}
       end
-
       if hash.key?('$ref')
         # Legacy dbref handling.
         # Note that according to extended json spec, only hash values (but
@@ -219,6 +218,14 @@ module BSON
             raise Error::ExtJSONParseError, "Invalid subType value in $binary: #{value}"
           end
           create_binary(encoded_value, subtype)
+
+        when '$uuid'
+          unless /\A[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\z/.match(hash['$uuid'])
+            raise Error::ExtJSONParseError, "Invalid $uuid value: #{hash}"
+          end
+
+          return Binary.from_uuid(hash['$uuid'])
+
         when '$code'
           unless value.is_a?(String)
             raise Error::ExtJSONParseError, "Invalid $code value: #{value}"
@@ -310,8 +317,6 @@ module BSON
 
           return create_binary(hash['$binary'], hash['$type'])
         end
-
-# TODO: add logic for $uuid
 
         if last_key == '$regex'
           unless sorted_keys == %w($options $regex)

--- a/spec/spec_tests/data/corpus/binary.json
+++ b/spec/spec_tests/data/corpus/binary.json
@@ -40,6 +40,12 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
         },
         {
+            "description": "subtype 0x04 UUID",
+            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+            "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
+        },
+        {
             "description": "subtype 0x05",
             "canonical_bson": "1D000000057800100000000573FFD26444B34C6990E8E7D1DFC035D400",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
@@ -80,6 +86,16 @@
         {
             "description": "subtype 0x02 length negative one",
             "bson": "130000000578000600000002FFFFFFFFFFFF00"
+        }
+    ],
+    "parseErrors": [
+        {
+            "description": "$uuid wrong type",
+            "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
+        },
+        {
+            "description": "$uuid invalid value",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
         }
     ]
 }


### PR DESCRIPTION
I added parsing logic in `ext_json.rb` to support parsing `$uuid` keys, and I synced our corpus spec tests to include the new uuid tests.