### PR TITLE
RUBY-2487 Add a local implementation of BSON::Document#except to work around ActiveSupport version not working correctly for symbol keys

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -560,10 +560,18 @@ axes:
   - id: "as"
     display_name: ActiveSupport
     values:
-      - id: "as"
-        display_name: AS
+      - id: "5.2"
+        display_name: 5.2
         variables:
-          WITH_ACTIVE_SUPPORT: true
+          WITH_ACTIVE_SUPPORT: "~> 5.2.0"
+      - id: "6.0"
+        display_name: 6.0
+        variables:
+          WITH_ACTIVE_SUPPORT: "~> 6.0.0"
+      - id: "6.1"
+        display_name: 6.1
+        variables:
+          WITH_ACTIVE_SUPPORT: "~> 6.1.0"
   - id: "compact"
     display_name: GC.compact
     values:
@@ -590,8 +598,8 @@ buildvariants:
      - name: "test"
 
 - matrix_name: "activesupport"
-  matrix_spec: { mri-rubies: "ruby-2.6", all-os: "ubuntu1404", as: as }
-  display_name: "AS ${mri-rubies}, ${all-os}"
+  matrix_spec: { mri-rubies: "ruby-2.6", all-os: "ubuntu1404", as: '*' }
+  display_name: "AS ${as} ${mri-rubies}, ${all-os}"
   tasks:
      - name: "test"
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,11 @@ group :development, :test do
 
   gem 'rspec', '~> 3'
   gem 'json'
-  gem 'activesupport'
+  if ENV['WITH_ACTIVE_SUPPORT'] =~ /[0-9]/ && ENV['WITH_ACTIVE_SUPPORT'] != '0'
+    gem 'activesupport', ENV['WITH_ACTIVE_SUPPORT']
+  else
+    gem 'activesupport'
+  end
   gem 'ruby-prof', platforms: :mri
 
   gem 'byebug', platforms: :mri

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -290,18 +290,23 @@ module BSON
       end
     end
 
-    # Slices a document to remove the given keys.
-    # Will normalize symbol keys into strings.
-    # (this method is backported from ActiveSupport::Hash)
+    # Returns a new document consisting of the current document minus the
+    # specified keys.
     #
-    # @example Get a document/hash with only the `name` and `age` fields present
+    # The keys to be removed can be specified as either strings or symbols.
+    #
+    # @example Get a document/hash with only the `name` and `age` fields removed
     #   document # => { _id: <ObjectId>, :name => 'John', :age => 30, :location => 'Earth' }
     #   document.except(:name, 'age') # => { _id: <ObjectId>, location: 'Earth' }
     #
     # @param [ Array<String, Symbol> ] *keys Keys, that will be removed in the resulting document
     #
-    # @return [ BSON::Document ] The document without the removed keys
+    # @return [ BSON::Document ] The document with the specified keys removed.
     #
+    # @note This method is always defined, even if Hash already contains a
+    #   definition of #except, because ActiveSupport unconditionally defines
+    #   its version of #except which doesn't work for BSON::Document which
+    #   causes problems if ActiveSupport is loaded after bson-ruby is.
     def except(*keys)
       copy = dup
       keys.each {|key| copy.delete(key)}

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -290,6 +290,24 @@ module BSON
       end
     end
 
+    # Slices a document to remove the given keys.
+    # Will normalize symbol keys into strings.
+    # (this method is backported from ActiveSupport::Hash)
+    #
+    # @example Get a document/hash with only the `name` and `age` fields present
+    #   document # => { _id: <ObjectId>, :name => 'John', :age => 30, :location => 'Earth' }
+    #   document.except(:name, 'age') # => { _id: <ObjectId>, location: 'Earth' }
+    #
+    # @param [ Array<String, Symbol> ] *keys Keys, that will be removed in the resulting document
+    #
+    # @return [ BSON::Document ] The document without the removed keys
+    #
+    def except(*keys)
+      copy = dup
+      keys.each {|key| copy.delete(key)}
+      copy
+    end
+
     private
 
     def convert_key(key)

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -229,24 +229,22 @@ describe BSON::Document do
     end
   end
 
-  if described_class.instance_methods.include?(:except)
-    describe "#except" do
-      let(:document) do
-        described_class.new("key1" => "value1", key2: "value2")
+  describe "#except" do
+    let(:document) do
+      described_class.new("key1" => "value1", key2: "value2")
+    end
+
+    context "when provided string keys" do
+
+      it "returns the partial document" do
+        expect(document.except("key1")).to contain_exactly(['key2', 'value2'])
       end
+    end
 
-      context "when provided string keys" do
+    context "when provided symbol keys" do
 
-        it "returns the partial document" do
-          expect(document.except("key1")).to contain_exactly(['key2', 'value2'])
-        end
-      end
-
-      context "when provided symbol keys" do
-
-        it "returns the partial document" do
-          expect(document.except(:key1)).to contain_exactly(['key2', 'value2'])
-        end
+      it "returns the partial document" do
+        expect(document.except(:key1)).to contain_exactly(['key2', 'value2'])
       end
     end
   end

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -229,6 +229,29 @@ describe BSON::Document do
     end
   end
 
+  if described_class.instance_methods.include?(:except)
+    describe "#except" do
+      let(:document) do
+        described_class.new("key1" => "value1", key2: "value2")
+      end
+
+      context "when provided string keys" do
+
+        it "returns the partial document" do
+          expect(document.except("key1")).to contain_exactly(['key2', 'value2'])
+        end
+      end
+
+      context "when provided symbol keys" do
+
+        it "returns the partial document" do
+          expect(document.except(:key1)).to contain_exactly(['key2', 'value2'])
+        end
+      end
+    end
+  end
+
+
   describe "#delete" do
 
     shared_examples_for "a document with deletable pairs" do

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -6,7 +6,8 @@ class SpecConfig
   COMPACTION_CHANCE = 0.001
 
   def active_support?
-    %w(1 true yes).include?(ENV['WITH_ACTIVE_SUPPORT'])
+    %w(1 true yes).include?(ENV['WITH_ACTIVE_SUPPORT']) ||
+      ENV['WITH_ACTIVE_SUPPORT'] =~ /[0-9]/ && ENV['WITH_ACTIVE_SUPPORT'] != '0'
   end
 
   def compact?


### PR DESCRIPTION
As described in https://jira.mongodb.org/projects/RUBY/issues/RUBY-2487

BSON::Document inherits `except` from Hash either when

- activesupport has added its extensions to Hash
- the ruby version is >= 3.0.0

The implementation in activesupport < 6.0 is such that keys were being
converted from symbols but this is not true of the implementation in
activesupport >= 6 or in ruby >= 3.0

Unlike `slice` this doesn't check whether the method is already defined - when I did that specs failed when run with WITH_ACTIVE_SUPPORT=1. I believe this is because active support is required after bson, so when bson/document.rb is being loaded `except` doesn't exist (yet) and active support later drops it's (bad) implementation on top.

I believe this same order loading thing affects slice - it is less obvious because ruby 2.5, 2.6 have Hash#slice builtin (so the code to override slice kicks in) but on ruby 2.4 I get a spec failure in the slice specs running `bundle exec rake spec WITH_ACTIVE_SUPPORT=1`

CI doesn't run with WITH_ACTIVE_SUPPORT=1 so the CI runs that are green below don't actually validate that the issue is fixed.

