### PR TITLE
RUBY-2491 RUBY-2504 Add slice method for all ruby versions, make it always return BSON::Document instances

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -604,7 +604,7 @@ buildvariants:
 - matrix_name: "activesupport"
   matrix_spec:
     mri-rubies: [ruby-2.5, ruby-2.6, ruby-2.7]
-    all-os: "ubuntu1404"
+    all-os: "ubuntu1604"
     as: '*'
   display_name: "AS ${as} ${mri-rubies}, ${all-os}"
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -560,6 +560,10 @@ axes:
   - id: "as"
     display_name: ActiveSupport
     values:
+      - id: "5.1"
+        display_name: 5.1
+        variables:
+          WITH_ACTIVE_SUPPORT: "~> 5.1.0"
       - id: "5.2"
         display_name: 5.2
         variables:
@@ -598,7 +602,19 @@ buildvariants:
      - name: "test"
 
 - matrix_name: "activesupport"
-  matrix_spec: { mri-rubies: "ruby-2.6", all-os: "ubuntu1404", as: '*' }
+  matrix_spec:
+    mri-rubies: [ruby-2.5, ruby-2.6, ruby-2.7]
+    all-os: "ubuntu1404"
+    as: '*'
+  display_name: "AS ${as} ${mri-rubies}, ${all-os}"
+  tasks:
+     - name: "test"
+
+- matrix_name: "activesupport-old-rubies"
+  matrix_spec:
+    mri-rubies: [ruby-2.3, ruby-2.4]
+    all-os: "ubuntu1404"
+    as: ['5.1', '5.2']
   display_name: "AS ${as} ${mri-rubies}, ${all-os}"
   tasks:
      - name: "test"

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -285,8 +285,11 @@ module BSON
     #
     # @since 4.3.1
     def slice(*keys)
-      keys.map{|key| convert_key(key)}
-          .each_with_object(BSON::Document.new) {|key, hash| hash[key] = self[key] if has_key?(key)}
+      keys.each_with_object(self.class.new) do |key, hash|
+        if key?(key)
+          hash[key] = self[key]
+        end
+      end
     end
 
     # Returns a new document consisting of the current document minus the

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -269,25 +269,24 @@ module BSON
       end
     end
 
-    if instance_methods.include?(:slice)
-      # Slices a document to include only the given keys.
-      # Will normalize symbol keys into strings.
-      # (this method is backported from ActiveSupport::Hash)
-      #
-      # @example Get a document/hash with only the `name` and `age` fields present
-      #   document # => { _id: <ObjectId>, :name => 'John', :age => 30, :location => 'Earth' }
-      #   document.slice(:name, 'age') # => { name: 'John', age: 30 }
-      #   document.slice('name') # => { name: 'John' }
-      #   document.slice(:foo) # => nil
-      #
-      # @param [ Array<String, Symbol> ] *keys Keys, that will be kept in the resulting document
-      #
-      # @return [ BSON::Document ] The document with only the selected keys
-      #
-      # @since 4.3.1
-      def slice(*keys)
-        super(*keys.map{|key| convert_key(key)})
-      end
+    # Slices a document to include only the given keys.
+    # Will normalize symbol keys into strings.
+    # (this method is backported from ActiveSupport::Hash)
+    #
+    # @example Get a document/hash with only the `name` and `age` fields present
+    #   document # => { _id: <ObjectId>, :name => "John", :age => 30, :location => "Earth" }
+    #   document.slice(:name, 'age') # => { "name": "John", "age" => 30 }
+    #   document.slice('name') # => { "name" => "John" }
+    #   document.slice(:foo) # => {}
+    #
+    # @param [ Array<String, Symbol> ] *keys Keys, that will be kept in the resulting document
+    #
+    # @return [ BSON::Document ] The document with only the selected keys
+    #
+    # @since 4.3.1
+    def slice(*keys)
+      keys.map{|key| convert_key(key)}
+          .each_with_object(BSON::Document.new) {|key, hash| hash[key] = self[key] if has_key?(key)}
     end
 
     # Returns a new document consisting of the current document minus the

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -215,6 +215,10 @@ describe BSON::Document do
 
       context "when provided string keys" do
 
+        it "is a BSON Document" do
+          expect(document.slice("key1")).to be_a(BSON::Document)
+        end
+
         it "returns the partial document" do
           expect(document.slice("key1")).to contain_exactly(['key1', 'value1'])
         end
@@ -222,8 +226,19 @@ describe BSON::Document do
 
       context "when provided symbol keys" do
 
+        it "is a BSON Document" do
+          expect(document.slice(:key1)).to be_a(BSON::Document)
+        end
+
         it "returns the partial document" do
           expect(document.slice(:key1)).to contain_exactly(['key1', 'value1'])
+        end
+      end
+
+      context "when provided keys that do not exist in the document" do
+
+        it "returns only the keys that exist in the document" do
+          expect(document.slice(:key1, :key3)).to contain_exactly(['key1', 'value1'])
         end
       end
     end


### PR DESCRIPTION
Backport the .slice method from ActiveSupport core ext  hash but maintain the logic to normalize the symbol keys into strings.
    
Updated inline documentation to match return values, these return values now match the return types from ActiveSupport core ext Hash

[ close RUBY-2491, RUBY-2504 ]