### PR TITLE
Draft: #as_json should be API-ready

### DIFF
--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -55,17 +55,16 @@ module BSON
     # @since 4.2.0
     NATIVE_TYPE = BigDecimal
 
-    # Get the Decimal128 as JSON hash data.
+    # Return a string representation of the Decimal128 use in standard
+    # application-level JSON serialization. This method is intentionally
+    # different from #as_extended_json.
     #
-    # @example Get the Decimal128 as a JSON hash.
+    # @example Get the Decimal128 as a JSON-serializable object.
     #   decimal.as_json
     #
-    # @return [ Hash ] The number as a JSON hash.
-    #
-    # @since 4.2.0
-    # @deprecated Use as_extended_json instead.
+    # @return [ String ] The object id as a string.
     def as_json(*args)
-      as_extended_json
+      to_s
     end
 
     # Converts this object to a representation directly serializable to

--- a/lib/bson/int32.rb
+++ b/lib/bson/int32.rb
@@ -117,6 +117,10 @@ module BSON
     alias :eql? :==
     alias :=== :==
 
+    def as_json(**options)
+      value
+    end
+
     # Converts this object to a representation directly serializable to
     # Extended JSON (https://github.com/mongodb/specifications/blob/master/source/extended-json.rst).
     #

--- a/lib/bson/int64.rb
+++ b/lib/bson/int64.rb
@@ -117,6 +117,10 @@ module BSON
     alias :eql? :==
     alias :=== :==
 
+    def as_json(**options)
+      value
+    end
+
     # Converts this object to a representation directly serializable to
     # Extended JSON (https://github.com/mongodb/specifications/blob/master/source/extended-json.rst).
     #

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -63,17 +63,16 @@ module BSON
       super
     end
 
-    # Return the object id as a JSON hash representation.
+    # Return a string representation of the object id for use in standard
+    # application-level JSON serialization. This method is intentionally
+    # different from #as_extended_json.
     #
-    # @example Get the object id as JSON.
+    # @example Get the object id as a JSON-serializable object.
     #   object_id.as_json
     #
-    # @return [ Hash ] The object id as a JSON hash.
-    #
-    # @since 2.0.0
-    # @deprecated Use as_extended_json instead.
+    # @return [ String ] The object id as a string.
     def as_json(*args)
-      as_extended_json
+      to_s
     end
 
     # Converts this object to a representation directly serializable to

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -55,18 +55,6 @@ module BSON
     # @deprecated Will be removed in 5.0
     RUBY_MULTILINE_VALUE = 'ms'.freeze
 
-    # Get the regexp as JSON hash data.
-    #
-    # @example Get the regexp as a JSON hash.
-    #   regexp.as_json
-    #
-    # @return [ Hash ] The regexp as a JSON hash.
-    #
-    # @since 2.0.0
-    def as_json(*args)
-      { "$regex" => source, "$options" => bson_options }
-    end
-
     # Get the regular expression as encoded BSON.
     #
     # @example Get the regular expression as encoded BSON.
@@ -211,7 +199,7 @@ module BSON
       #
       # @since 4.2.0
       def as_json(*args)
-        as_extended_json(mode: :legacy)
+        compile.to_s
       end
 
       # Converts this object to a representation directly serializable to

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -76,17 +76,24 @@ module BSON
       [ a, b ].sort[0] == a ? -1 : 1
     end
 
+    # Compile the Timestamp into a native Time type.
+    #
+    # @example Compile the timestamp.
+    #   timestamp.compile
+    #
+    # @return [ ::Time ] The compiled timestamp.
+    def compile
+      ::Time.at(seconds).utc
+    end
+
     # Get the timestamp as JSON hash data.
     #
     # @example Get the timestamp as a JSON hash.
     #   timestamp.as_json
     #
-    # @return [ Hash ] The timestamp as a JSON hash.
-    #
-    # @since 2.0.0
-    # @deprecated Use as_extended_json instead.
+    # @return [ Time ] The timestamp as a JSON hash.
     def as_json(*args)
-      as_extended_json
+      compile
     end
 
     # Converts this object to a representation directly serializable to


### PR DESCRIPTION
### Work In Progress - Not Ready for Merge

#as_json should return objects for API serialization, and be different than #as_extended JSON.

The general rules for `#as_json` are (in order of precedence):

1. Map directly to a [native JSON type](https://www.json.org/json-en.html) if it is possible to do so. Examples:
   * BSON::ObjectId --> JSON String
   * BSON::Int32 / Int64 --> JSON Integer

2. Where ActiveSupport defines `#as_json` behavior for a Ruby object, follow the same. Examples:
   * BSON::Regexp::Raw --> Ruby Regex --> JSON String `"(?-mix:dsfsd|dsf)"`
   * BSON::Timestamp --> Ruby Time --> JSON String (time)
   * BSON::Decimal128 --> (similar to Ruby BigDecimal) --> JSON String `"1234"`

3. For the remaining types not mentioned above, we need to decide whether we go with:

(a) alias to `#as_extended_json`
(b) compound object (Hash)
(c) compacted (lossy) single value representation

   * lib/bson/binary.rb  --> could just return the base64, but we'd lose the `type`
   * lib/bson/code.rb --> can return code as string
   * lib/bson/code_with_scope.rb --> can return code as string but we'd lose the `scope`
   * lib/bson/db_pointer.rb --> could return just the objectId but we'd lose the `ref` (collection)
   * lib/bson/max_key.rb --> either { "$maxKey" => 1 } or `"$maxKey"`
   * lib/bson/min_key.rb --> either { "$minKey" => 1 } or `"$minKey"`