### PR TITLE
MONGOID-5158 - Part III - Add #as_extended_json handling to Date and DateTime

### DIFF
--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -54,6 +54,22 @@ module BSON
     def bson_type
       ::Time::BSON_TYPE
     end
+
+    # Converts this object to a representation directly serializable to
+    # Extended JSON (https://github.com/mongodb/specifications/blob/master/source/extended-json.rst).
+    #
+    # @option opts [ nil | :relaxed | :legacy ] :mode Serialization mode
+    #   (default is canonical extended JSON)
+    #
+    # @return [ Hash ] The extended json representation.
+    def as_extended_json(**options)
+      value = if options[:mode] == :relaxed && (1970..9999).include?(year)
+                strftime('%Y-%m-%dT00:00:00Z')
+              else
+                { '$numberLong' => strftime('%Q') }
+              end
+      { '$date' => value }
+    end
   end
 
   # Enrich the core Date class with this module.

--- a/lib/bson/date_time.rb
+++ b/lib/bson/date_time.rb
@@ -37,6 +37,19 @@ module BSON
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       gregorian.to_time.to_bson(buffer)
     end
+
+    # Converts this object to a representation directly serializable to
+    # Extended JSON (https://github.com/mongodb/specifications/blob/master/source/extended-json.rst).
+    #
+    # @note The time is floored to the nearest millisecond.
+    #
+    # @option opts [ nil | :relaxed | :legacy ] :mode Serialization mode
+    #   (default is canonical extended JSON)
+    #
+    # @return [ Hash ] The extended json representation.
+    def as_extended_json(**options)
+      to_time.utc.as_extended_json(**options)
+    end
   end
 
   # Enrich the core DateTime class with this module.

--- a/lib/bson/time.rb
+++ b/lib/bson/time.rb
@@ -63,8 +63,8 @@ module BSON
     #
     # @note The time is floored to the nearest millisecond.
     #
-    # @option options [ true | false ] :relaxed Whether to produce relaxed
-    #   extended JSON representation.
+    # @option opts [ nil | :relaxed | :legacy ] :mode Serialization mode
+    #   (default is canonical extended JSON)
     #
     # @return [ Hash ] The extended json representation.
     def as_extended_json(**options)
@@ -77,14 +77,14 @@ module BSON
           else
             utc_time -= utc_time.usec.divmod(1000).last.to_r / 1000000
           end
-          {'$date' => utc_time.strftime('%Y-%m-%dT%H:%M:%S.%LZ')}
+          { '$date' => utc_time.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }
         else
-          {'$date' => utc_time.strftime('%Y-%m-%dT%H:%M:%SZ')}
+          { '$date' => utc_time.strftime('%Y-%m-%dT%H:%M:%SZ') }
         end
       else
         sec = utc_time._bson_to_i
         msec = utc_time.usec.divmod(1000).first
-        {'$date' => {'$numberLong' => (sec * 1000 + msec).to_s}}
+        { '$date' => { '$numberLong' => (sec * 1000 + msec).to_s } }
       end
     end
 

--- a/spec/bson/date_spec.rb
+++ b/spec/bson/date_spec.rb
@@ -38,4 +38,174 @@ describe Date do
       it_behaves_like "a serializable bson element"
     end
   end
+
+  describe '#as_extended_json' do
+
+    context 'canonical mode' do
+
+      let(:serialization) do
+        obj.as_extended_json
+      end
+
+      context 'when the time within epoch' do
+        let(:obj) { Date.new(2012, 1, 1) }
+
+        let(:expected_serialization) do
+          { "$date" => { "$numberLong" => "1325376000000" } }
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the year precedes epoch" do
+        let(:obj) { Date.new(1960, 1, 1) }
+
+        let(:expected_serialization) do
+          { "$date" => { "$numberLong" => "-315619200000" } }
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the year exceeds 9999" do
+        let(:obj) { Time.utc(10000, 1, 1) }
+
+        let(:expected_serialization) do
+          { "$date" => { "$numberLong" => "253402300800000" } }
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+
+    context 'relaxed mode' do
+
+      let(:serialization) do
+        obj.as_extended_json(mode: :relaxed)
+      end
+
+      context 'when the time within epoch' do
+        let(:obj) { Date.new(2012, 1, 1) }
+
+        let(:expected_serialization) do
+          { "$date" => "2012-01-01T00:00:00Z" }
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the year precedes epoch" do
+        let(:obj) { Date.new(1960, 1, 1) }
+
+        let(:expected_serialization) do
+          { "$date" => { "$numberLong" => "-315619200000" } }
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the year exceeds 9999" do
+        let(:obj) { Time.utc(10000, 1, 1) }
+
+        let(:expected_serialization) do
+          { "$date" => { "$numberLong" => "253402300800000" } }
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+  end
+
+  describe '#to_extended_json' do
+
+    context 'canonical mode' do
+
+      let(:serialization) do
+        obj.to_extended_json
+      end
+
+      context 'when the time within epoch' do
+        let(:obj) { Date.new(2012, 1, 1) }
+
+        let(:expected_serialization) do
+          %q`{"$date":{"$numberLong":"1325376000000"}}`
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the year precedes epoch" do
+        let(:obj) { Date.new(1960, 1, 1) }
+
+        let(:expected_serialization) do
+          %q`{"$date":{"$numberLong":"-315619200000"}}`
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the year exceeds 9999" do
+        let(:obj) { Time.utc(10000, 1, 1) }
+
+        let(:expected_serialization) do
+          %q`{"$date":{"$numberLong":"253402300800000"}}`
+        end
+
+        it 'correctly serializes the date' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+
+    context 'relaxed mode' do
+      let(:obj) { Time.utc(2012, 1, 1) }
+
+      let(:expected_serialization) do
+        %q`{"$date":"2012-01-01T00:00:00Z"}`
+      end
+
+      let(:serialization) do
+        obj.to_extended_json(mode: :relaxed)
+      end
+
+      it 'correctly serializes the date' do
+        expect(serialization).to eq expected_serialization
+      end
+    end
+  end
+
+  describe '#to_json' do
+
+    let(:obj) { Date.new(2012, 1, 1) }
+
+    let(:expected_serialization) do
+      %q`"2012-01-01"`
+    end
+
+    let(:serialization) do
+      obj.to_json
+    end
+
+    it 'correctly serializes the date' do
+      expect(serialization).to eq expected_serialization
+    end
+
+    it_behaves_like "a JSON serializable object"
+  end
 end

--- a/spec/bson/date_time_spec.rb
+++ b/spec/bson/date_time_spec.rb
@@ -22,7 +22,7 @@ describe DateTime do
 
     context "when the date time is post epoch" do
 
-      let(:obj)  { DateTime.new(2012, 1, 1, 0, 0, 0) }
+      let(:obj) { DateTime.new(2012, 1, 1, 0, 0, 0) }
       let(:bson) { [ (obj.to_time.to_f * 1000).to_i ].pack(BSON::Int64::PACK) }
 
       it_behaves_like "a serializable bson element"
@@ -30,15 +30,15 @@ describe DateTime do
 
     context "when the date time is pre epoch" do
 
-      let(:obj)  { DateTime.new(1969, 1, 1, 0, 0, 0) }
+      let(:obj) { DateTime.new(1969, 1, 1, 0, 0, 0) }
       let(:bson) { [ (obj.to_time.to_f * 1000).to_i ].pack(BSON::Int64::PACK) }
 
       it_behaves_like "a serializable bson element"
     end
 
     context "when the dates don't both use Gregorian" do
-      
-      let(:shakespeare_datetime) do 
+
+      let(:shakespeare_datetime) do
         DateTime.iso8601('1616-04-23', Date::ENGLAND)
       end
 
@@ -46,8 +46,8 @@ describe DateTime do
         DateTime.iso8601('1616-04-23', Date::GREGORIAN)
       end
 
-      context "when putting to bson" do 
-        
+      context "when putting to bson" do
+
         let(:shakespeare) do
           { a: shakespeare_datetime }.to_bson
         end
@@ -56,16 +56,16 @@ describe DateTime do
           { a: gregorian_datetime }.to_bson
         end
 
-        it "does not equal each other" do 
+        it "does not equal each other" do
           expect(shakespeare.to_s).to_not eq(gregorian.to_s)
         end
 
-        it "the english date is 10 days later" do 
+        it "the english date is 10 days later" do
           expect(shakespeare.to_s).to eq({ a: DateTime.iso8601('1616-05-03', Date::GREGORIAN) }.to_bson.to_s)
         end
       end
 
-      context "when putting and receiving from bson" do 
+      context "when putting and receiving from bson" do
 
         let(:shakespeare) do
           Hash.from_bson(BSON::ByteBuffer.new({ a: shakespeare_datetime }.to_bson.to_s))
@@ -86,6 +86,175 @@ describe DateTime do
         it "the gregorian date is the same" do
           expect(gregorian[:a]).to eq(DateTime.iso8601('1616-04-23', Date::GREGORIAN).to_time)
         end
+      end
+    end
+  end
+
+  describe '#as_extended_json' do
+    let(:object) { DateTime.new(2012, 1, 1, 0, 0, 0.999999) }
+
+    context 'canonical mode' do
+      let(:expected_serialization) do
+        { '$date' => { '$numberLong' => '1325376000999' } }
+      end
+
+      let(:serialization) do
+        object.as_extended_json
+      end
+
+      it 'truncates to milliseconds when serializing' do
+        expect(serialization).to eq expected_serialization
+      end
+
+      context 'when value has sub-microsecond precision' do
+        let(:object) { DateTime.new(2012, 1, 1, 0, 0, 999_999_999/1_000_000_000r) }
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the time precedes epoch" do
+        let(:object) { DateTime.new(1960, 1, 1, 0, 0, 0.999999) }
+
+        let(:expected_serialization) do
+          { '$date' => { '$numberLong' => '-315619199001' } }
+        end
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+
+    context 'relaxed mode' do
+      let(:expected_serialization) do
+        { '$date' => '2012-01-01T00:00:00.999Z' }
+      end
+
+      let(:serialization) do
+        object.as_extended_json(mode: :relaxed)
+      end
+
+      it 'truncates to milliseconds when serializing' do
+        expect(serialization).to eq expected_serialization
+      end
+
+      context 'when value has sub-microsecond precision' do
+        let(:object) { DateTime.new(2012, 1, 1, 0, 0, 999_999_999/1_000_000_000r) }
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the time precedes epoch" do
+        let(:object) { DateTime.new(1960, 1, 1, 0, 0, 0.999999) }
+
+        let(:expected_serialization) do
+          { '$date' => { '$numberLong' => '-315619199001' } }
+        end
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+  end
+
+  describe '#to_extended_json' do
+    let(:object) { DateTime.new(2012, 1, 1, 0, 0, 0.999999) }
+
+    context 'canonical mode' do
+
+      let(:expected_serialization) do
+        %q`{"$date":{"$numberLong":"1325376000999"}}`
+      end
+
+      let(:serialization) do
+        object.to_extended_json
+      end
+
+      it 'truncates to milliseconds when serializing' do
+        expect(serialization).to eq expected_serialization
+      end
+
+      context 'when value has sub-microsecond precision' do
+        let(:object) { DateTime.new(2012, 1, 1, 0, 0, 999_999_999/1_000_000_000r) }
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+
+      context "when the time precedes epoch" do
+        let(:object) { DateTime.new(1960, 1, 1, 0, 0, 0.999999) }
+
+        let(:expected_serialization) do
+          %q`{"$date":{"$numberLong":"-315619199001"}}`
+        end
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+
+    context 'relaxed mode' do
+      let(:expected_serialization) do
+        %q`{"$date":"2012-01-01T00:00:00.999Z"}`
+      end
+
+      let(:serialization) do
+        object.to_extended_json(mode: :relaxed)
+      end
+
+      it 'truncates to milliseconds when serializing' do
+        expect(serialization).to eq expected_serialization
+      end
+
+      context 'when value has sub-microsecond precision' do
+        let(:object) { DateTime.new(2012, 1, 1, 0, 0, 999_999_999/1_000_000_000r) }
+
+        it 'truncates to milliseconds when serializing' do
+          expect(serialization).to eq expected_serialization
+        end
+      end
+    end
+  end
+
+  describe '#to_json' do
+    let(:object) { DateTime.new(2012, 1, 1, 0, 0, 0.999999) }
+
+    let(:expected_serialization) do
+      %q`"2012-01-01T00:00:00+00:00"`
+    end
+
+    let(:serialization) do
+      object.to_json
+    end
+
+    it 'truncates to milliseconds when serializing' do
+      expect(serialization).to eq expected_serialization
+    end
+
+    context 'when value has sub-microsecond precision' do
+      let(:object) { DateTime.new(2012, 1, 1, 0, 0, 999_999_999/1_000_000_000r) }
+
+      it 'truncates to milliseconds when serializing' do
+        expect(serialization).to eq expected_serialization
+      end
+    end
+
+    context "when the time precedes epoch" do
+      let(:object) { DateTime.new(1960, 1, 1, 0, 0, 0.999999) }
+
+      let(:expected_serialization) do
+        %q`"1960-01-01T00:00:00+00:00"`
+      end
+
+      it 'truncates to milliseconds when serializing' do
+        expect(serialization).to eq expected_serialization
       end
     end
   end


### PR DESCRIPTION
This PR fixes #as_extended_json for Date and DateTime, which were both missing it.

Note that DateTime converts to Time (`#to_time`) to keep the code simple.

There is no change to the Time class implementation, however I've cleaned up the specs a bit to match the other two classes.