### PR TITLE
freeze string literals

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -44,12 +44,12 @@ module BSON
   # Constant for bson types that don't actually serialize a value.
   #
   # @since 2.0.0
-  NO_VALUE = -("".b)
+  NO_VALUE = ::String.new("", encoding: BINARY).freeze
 
   # Constant for a null byte (0x00).
   #
   # @since 2.0.0
-  NULL_BYTE = -(0.chr.b)
+  NULL_BYTE = ::String.new(0.chr, encoding: BINARY).freeze
 
   # Constant for UTF-8 string encoding.
   #

--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -44,7 +44,7 @@ module BSON
   # Constant for bson types that don't actually serialize a value.
   #
   # @since 2.0.0
-  NO_VALUE = ::String.new("", encoding: BINARY).freeze
+  NO_VALUE = ::String.new(encoding: BINARY).freeze
 
   # Constant for a null byte (0x00).
   #

--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,22 +39,22 @@ module BSON
   # Constant for binary string encoding.
   #
   # @since 2.0.0
-  BINARY = "BINARY".freeze
+  BINARY = "BINARY"
 
   # Constant for bson types that don't actually serialize a value.
   #
   # @since 2.0.0
-  NO_VALUE = "".force_encoding(BINARY).freeze
+  NO_VALUE = -("".b)
 
   # Constant for a null byte (0x00).
   #
   # @since 2.0.0
-  NULL_BYTE = 0.chr.force_encoding(BINARY).freeze
+  NULL_BYTE = -(0.chr.b)
 
   # Constant for UTF-8 string encoding.
   #
   # @since 2.0.0
-  UTF8 = "UTF-8".freeze
+  UTF8 = "UTF-8"
 end
 
 require "bson/config"

--- a/lib/bson/active_support.rb
+++ b/lib/bson/active_support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2018-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/array.rb
+++ b/lib/bson/array.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # An array is type 0x04 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 4.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(4.chr.b)
 
     # Get the array as encoded BSON.
     #

--- a/lib/bson/array.rb
+++ b/lib/bson/array.rb
@@ -26,7 +26,7 @@ module BSON
     # An array is type 0x04 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(4.chr.b)
+    BSON_TYPE = ::String.new(4.chr, encoding: BINARY).freeze
 
     # Get the array as encoded BSON.
     #

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +28,7 @@ module BSON
     # A binary is type 0x05 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 5.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(5.chr.b)
 
     # The mappings of subtypes to their single byte identifiers.
     #

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -28,7 +28,7 @@ module BSON
     # A binary is type 0x05 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(5.chr.b)
+    BSON_TYPE = ::String.new(5.chr, encoding: BINARY).freeze
 
     # The mappings of subtypes to their single byte identifiers.
     #

--- a/lib/bson/boolean.rb
+++ b/lib/bson/boolean.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # A boolean is type 0x08 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 8.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(8.chr.b)
 
     # Deserialize a boolean from BSON.
     #

--- a/lib/bson/boolean.rb
+++ b/lib/bson/boolean.rb
@@ -26,7 +26,7 @@ module BSON
     # A boolean is type 0x08 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(8.chr.b)
+    BSON_TYPE = ::String.new(8.chr, encoding: BINARY).freeze
 
     # Deserialize a boolean from BSON.
     #

--- a/lib/bson/code.rb
+++ b/lib/bson/code.rb
@@ -26,7 +26,7 @@ module BSON
     # A code is type 0x0D in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(13.chr.b)
+    BSON_TYPE = ::String.new(13.chr, encoding: BINARY).freeze
 
     # @!attribute javascript
     #   @return [ String ] The javascript code.

--- a/lib/bson/code.rb
+++ b/lib/bson/code.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # A code is type 0x0D in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 13.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(13.chr.b)
 
     # @!attribute javascript
     #   @return [ String ] The javascript code.

--- a/lib/bson/code_with_scope.rb
+++ b/lib/bson/code_with_scope.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +27,7 @@ module BSON
     # A code with scope is type 0x0F in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 15.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(15.chr.b)
 
     # @!attribute javascript
     #   @return [ String ] The javascript code.

--- a/lib/bson/code_with_scope.rb
+++ b/lib/bson/code_with_scope.rb
@@ -27,7 +27,7 @@ module BSON
     # A code with scope is type 0x0F in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(15.chr.b)
+    BSON_TYPE = ::String.new(15.chr, encoding: BINARY).freeze
 
     # @!attribute javascript
     #   @return [ String ] The javascript code.

--- a/lib/bson/config.rb
+++ b/lib/bson/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/date_time.rb
+++ b/lib/bson/date_time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/db_pointer.rb
+++ b/lib/bson/db_pointer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +23,7 @@ module BSON
     include JSON
 
     # A DBPointer is type 0x0C in the BSON spec.
-    BSON_TYPE = 0x0C.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(0x0C.chr.b)
 
     # Create a new DBPointer object.
     #

--- a/lib/bson/db_pointer.rb
+++ b/lib/bson/db_pointer.rb
@@ -23,7 +23,7 @@ module BSON
     include JSON
 
     # A DBPointer is type 0x0C in the BSON spec.
-    BSON_TYPE = -(0x0C.chr.b)
+    BSON_TYPE = ::String.new(0x0C.chr, encoding: BINARY).freeze
 
     # Create a new DBPointer object.
     #

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -24,7 +24,7 @@ module BSON
     # A Decimal128 is type 0x13 in the BSON spec.
     #
     # @since 4.2.0
-    BSON_TYPE = -(19.chr.b)
+    BSON_TYPE = ::String.new(19.chr, encoding: BINARY).freeze
 
     # Exponent offset.
     #

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,32 +24,32 @@ module BSON
     # A Decimal128 is type 0x13 in the BSON spec.
     #
     # @since 4.2.0
-    BSON_TYPE = 19.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(19.chr.b)
 
     # Exponent offset.
     #
     # @since 4.2.0
-    EXPONENT_OFFSET = 6176.freeze
+    EXPONENT_OFFSET = 6176
 
     # Minimum exponent.
     #
     # @since 4.2.0
-    MIN_EXPONENT = -6176.freeze
+    MIN_EXPONENT = -6176
 
     # Maximum exponent.
     #
     # @since 4.2.0
-    MAX_EXPONENT = 6111.freeze
+    MAX_EXPONENT = 6111
 
     # Maximum digits of precision.
     #
     # @since 4.2.0
-    MAX_DIGITS_OF_PRECISION = 34.freeze
+    MAX_DIGITS_OF_PRECISION = 34
 
     # Key for this type when converted to extended json.
     #
     # @since 4.2.0
-    EXTENDED_JSON_KEY = "$numberDecimal".freeze
+    EXTENDED_JSON_KEY = "$numberDecimal"
 
     # The native type to which this object can be converted.
     #
@@ -263,7 +264,7 @@ module BSON
       # The custom error message for this error.
       #
       # @since 4.2.0
-      MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'.freeze
+      MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'
 
       # Get the custom error message for the exception.
       #
@@ -289,7 +290,7 @@ module BSON
       # The custom error message for this error.
       #
       # @since 4.2.0
-      MESSAGE = 'Invalid string format for creating a Decimal128 object.'.freeze
+      MESSAGE = 'Invalid string format for creating a Decimal128 object.'
 
       # Get the custom error message for the exception.
       #
@@ -314,7 +315,7 @@ module BSON
       # The custom error message for this error.
       #
       # @since 4.2.0
-      MESSAGE = 'Value out of range for Decimal128 representation.'.freeze
+      MESSAGE = 'Value out of range for Decimal128 representation.'
 
       # Get the custom error message for the exception.
       #

--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -367,6 +367,8 @@ module BSON
         #
         # @return [ String ] The string representing the decimal128 object.
         #
+        # @note The returned string may be frozen.
+        #
         # @since 4.2.0
         def string
           return NAN_STRING if nan?

--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,27 +27,27 @@ module BSON
       # Infinity mask.
       #
       # @since 4.2.0
-      INFINITY_MASK = 0x7800000000000000.freeze
+      INFINITY_MASK = 0x7800000000000000
 
       # NaN mask.
       #
       # @since 4.2.0
-      NAN_MASK = 0x7c00000000000000.freeze
+      NAN_MASK = 0x7c00000000000000
 
       # SNaN mask.
       #
       # @since 4.2.0
-      SNAN_MASK = (1 << 57).freeze
+      SNAN_MASK = (1 << 57)
 
       # Signed bit mask.
       #
       # @since 4.2.0
-      SIGN_BIT_MASK = (1 << 63).freeze
+      SIGN_BIT_MASK = (1 << 63)
 
       # The two highest bits of the 64 high order bits.
       #
       # @since 4.2.0
-      TWO_HIGHEST_BITS_SET = (3 << 61).freeze
+      TWO_HIGHEST_BITS_SET = (3 << 61)
 
       extend self
 
@@ -109,14 +110,14 @@ module BSON
         # @return [ Regex ] A regex matching a NaN string.
         #
         # @since 4.2.0
-        NAN_REGEX = /^(\-)?(S)?NaN$/i.freeze
+        NAN_REGEX = /^(\-)?(S)?NaN$/i
 
         # Regex matching a string representing positive or negative Infinity.
         #
         # @return [ Regex ] A regex matching a positive or negative Infinity string.
         #
         # @since 4.2.0
-        INFINITY_REGEX = /^(\+|\-)?Inf(inity)?$/i.freeze
+        INFINITY_REGEX = /^(\+|\-)?Inf(inity)?$/i
 
         # Regex for the fraction, including leading zeros.
         #
@@ -124,33 +125,33 @@ module BSON
         #   including leading zeros.
         #
         # @since 4.2.0
-        SIGNIFICAND_WITH_LEADING_ZEROS_REGEX = /(0*)(\d+)/.freeze
+        SIGNIFICAND_WITH_LEADING_ZEROS_REGEX = /(0*)(\d+)/
 
         # Regex for separating a negative sign from the significands.
         #
         # @return [ Regex ] The regex for separating a sign from significands.
         #
         # @since 4.2.0
-        SIGN_AND_DIGITS_REGEX = /^(\-)?(\S+)/.freeze
+        SIGN_AND_DIGITS_REGEX = /^(\-)?(\S+)/
 
         # Regex matching a scientific exponent.
         #
         # @return [ Regex ] A regex matching E, e, E+, e+.
         #
         # @since 4.2.0
-        SCIENTIFIC_EXPONENT_REGEX = /E\+?/i.freeze
+        SCIENTIFIC_EXPONENT_REGEX = /E\+?/i
 
         # Regex for capturing trailing zeros.
         #
         # @since 4.2.0
-        TRAILING_ZEROS_REGEX = /[1-9]*(0+)$/.freeze
+        TRAILING_ZEROS_REGEX = /[1-9]*(0+)$/
 
         # Regex for a valid decimal128 string format.
         #
         # @return [ Regex ] The regex for a valid decimal128 string.
         #
         # @since 4.2.0
-        VALID_DECIMAL128_STRING_REGEX = /^[\-\+]?(\d+(\.\d*)?|\.\d+)(E[\-\+]?\d+)?$/i.freeze
+        VALID_DECIMAL128_STRING_REGEX = /^[\-\+]?(\d+(\.\d*)?|\.\d+)(E[\-\+]?\d+)?$/i
 
         # Initialize the FromString Builder object.
         #
@@ -337,14 +338,14 @@ module BSON
         # @return [ String ] The string representing NaN.
         #
         # @since 4.2.0
-        NAN_STRING = 'NaN'.freeze
+        NAN_STRING = 'NaN'
 
         # String representing an Infinity value.
         #
         # @return [ String ] The string representing Infinity.
         #
         # @since 4.2.0
-        INFINITY_STRING = 'Infinity'.freeze
+        INFINITY_STRING = 'Infinity'
 
         # Initialize the FromBigDecimal Builder object.
         #
@@ -370,7 +371,7 @@ module BSON
         def string
           return NAN_STRING if nan?
           str = infinity? ? INFINITY_STRING : create_string
-          negative? ? '-' << str : str
+          negative? ? "-#{str}" : str
         end
 
         private

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/environment.rb
+++ b/lib/bson/environment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/error.rb
+++ b/lib/bson/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module BSON
   # Base exception class for all BSON-related errors.
   #

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2019-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/false_class.rb
+++ b/lib/bson/false_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # A false value in the BSON spec is 0x00.
     #
     # @since 2.0.0
-    FALSE_BYTE = 0.chr.force_encoding(BINARY).freeze
+    FALSE_BYTE = -(0.chr.b)
 
     # The BSON type for false values is the general boolean type of 0x08.
     #

--- a/lib/bson/false_class.rb
+++ b/lib/bson/false_class.rb
@@ -26,7 +26,7 @@ module BSON
     # A false value in the BSON spec is 0x00.
     #
     # @since 2.0.0
-    FALSE_BYTE = -(0.chr.b)
+    FALSE_BYTE = String.new(0.chr, encoding: BINARY).freeze
 
     # The BSON type for false values is the general boolean type of 0x08.
     #

--- a/lib/bson/float.rb
+++ b/lib/bson/float.rb
@@ -26,7 +26,7 @@ module BSON
     # A floating point is type 0x01 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(1.chr.b)
+    BSON_TYPE = ::String.new(1.chr, encoding: BINARY).freeze
 
     # The pack directive is for 8 byte floating points.
     #

--- a/lib/bson/float.rb
+++ b/lib/bson/float.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,12 +26,12 @@ module BSON
     # A floating point is type 0x01 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 1.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(1.chr.b)
 
     # The pack directive is for 8 byte floating points.
     #
     # @since 2.0.0
-    PACK = "E".freeze
+    PACK = "E"
 
     # Get the floating point as encoded BSON.
     #

--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -26,7 +26,7 @@ module BSON
     # A hash, also called an embedded document, is type 0x03 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(3.chr.b)
+    BSON_TYPE = ::String.new(3.chr, encoding: BINARY).freeze
 
     # Get the hash as encoded BSON.
     #

--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # A hash, also called an embedded document, is type 0x03 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 3.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(3.chr.b)
 
     # Get the hash as encoded BSON.
     #

--- a/lib/bson/int32.rb
+++ b/lib/bson/int32.rb
@@ -26,7 +26,7 @@ module BSON
     # A boolean is type 0x08 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(16.chr.b)
+    BSON_TYPE = ::String.new(16.chr, encoding: BINARY).freeze
 
     # The number of bytes constant.
     #

--- a/lib/bson/int32.rb
+++ b/lib/bson/int32.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # A boolean is type 0x08 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 16.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(16.chr.b)
 
     # The number of bytes constant.
     #
@@ -35,7 +36,7 @@ module BSON
     # Constant for the int 32 pack directive.
     #
     # @since 2.0.0
-    PACK = "l<".freeze
+    PACK = "l<"
 
     # Deserialize an Integer from BSON.
     #

--- a/lib/bson/int64.rb
+++ b/lib/bson/int64.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,12 +26,12 @@ module BSON
     # A boolean is type 0x08 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 18.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(18.chr.b)
 
     # Constant for the int 64 pack directive.
     #
     # @since 2.0.0
-    PACK = "q<".freeze
+    PACK = "q<"
 
     # Deserialize an Integer from BSON.
     #

--- a/lib/bson/int64.rb
+++ b/lib/bson/int64.rb
@@ -26,7 +26,7 @@ module BSON
     # A boolean is type 0x08 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(18.chr.b)
+    BSON_TYPE = ::String.new(18.chr, encoding: BINARY).freeze
 
     # Constant for the int 64 pack directive.
     #

--- a/lib/bson/integer.rb
+++ b/lib/bson/integer.rb
@@ -52,7 +52,7 @@ module BSON
     #
     # @since 2.0.0
     BSON_ARRAY_INDEXES = ::Array.new(BSON_INDEX_SIZE) do |i|
-      -(i.to_s.b << NULL_BYTE)
+      (i.to_s.b << NULL_BYTE).freeze
     end.freeze
 
     # Is this integer a valid BSON 32 bit value?

--- a/lib/bson/integer.rb
+++ b/lib/bson/integer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,13 +46,13 @@ module BSON
     # The BSON index size.
     #
     # @since 2.0.0
-    BSON_INDEX_SIZE = 1024.freeze
+    BSON_INDEX_SIZE = 1024
 
     # A hash of index values for array optimization.
     #
     # @since 2.0.0
     BSON_ARRAY_INDEXES = ::Array.new(BSON_INDEX_SIZE) do |i|
-      (i.to_s.force_encoding(BINARY) << NULL_BYTE).freeze
+      -(i.to_s.b << NULL_BYTE)
     end.freeze
 
     # Is this integer a valid BSON 32 bit value?

--- a/lib/bson/json.rb
+++ b/lib/bson/json.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/max_key.rb
+++ b/lib/bson/max_key.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,12 +29,12 @@ module BSON
     # A $maxKey is type 0x7F in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 127.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(127.chr.b)
 
     # Constant for always evaluating greater in a comparison.
     #
     # @since 2.0.0
-    GREATER = 1.freeze
+    GREATER = 1
 
     # When comparing a max key with any other object, the max key will always
     # be greater.

--- a/lib/bson/max_key.rb
+++ b/lib/bson/max_key.rb
@@ -29,7 +29,7 @@ module BSON
     # A $maxKey is type 0x7F in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(127.chr.b)
+    BSON_TYPE = ::String.new(127.chr, encoding: BINARY).freeze
 
     # Constant for always evaluating greater in a comparison.
     #

--- a/lib/bson/min_key.rb
+++ b/lib/bson/min_key.rb
@@ -29,7 +29,7 @@ module BSON
     # A $minKey is type 0xFF in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(255.chr.b)
+    BSON_TYPE = ::String.new(255.chr, encoding: BINARY).freeze
 
     # Constant for always evaluating lesser in a comparison.
     #

--- a/lib/bson/min_key.rb
+++ b/lib/bson/min_key.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,12 +29,12 @@ module BSON
     # A $minKey is type 0xFF in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 255.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(255.chr.b)
 
     # Constant for always evaluating lesser in a comparison.
     #
     # @since 2.0.0
-    LESSER = -1.freeze
+    LESSER = -1
 
     # When comparing a min key with any other object, the min key will always
     # be lesser.

--- a/lib/bson/nil_class.rb
+++ b/lib/bson/nil_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +27,7 @@ module BSON
     # A nil is type 0x0A in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 10.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(10.chr.b)
 
     module ClassMethods
 

--- a/lib/bson/nil_class.rb
+++ b/lib/bson/nil_class.rb
@@ -27,7 +27,7 @@ module BSON
     # A nil is type 0x0A in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(10.chr.b)
+    BSON_TYPE = ::String.new(10.chr, encoding: BINARY).freeze
 
     module ClassMethods
 

--- a/lib/bson/object.rb
+++ b/lib/bson/object.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +31,7 @@ module BSON
     # A object_id is type 0x07 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 7.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(7.chr.b)
 
     # Check equality of the object id with another object.
     #

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -31,7 +31,7 @@ module BSON
     # A object_id is type 0x07 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(7.chr.b)
+    BSON_TYPE = ::String.new(7.chr, encoding: BINARY).freeze
 
     # Check equality of the object id with another object.
     #

--- a/lib/bson/open_struct.rb
+++ b/lib/bson/open_struct.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,34 +27,34 @@ module BSON
     # A regular expression is type 0x0B in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 11.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(11.chr.b)
 
     # Extended value constant.
     #
     # @since 3.2.6
-    EXTENDED_VALUE = 'x'.freeze
+    EXTENDED_VALUE = 'x'
 
     # Ignore case constant.
     #
     # @since 3.2.6
-    IGNORECASE_VALUE = 'i'.freeze
+    IGNORECASE_VALUE = 'i'
 
     # Multiline constant.
     #
     # @since 3.2.6
-    MULTILINE_VALUE = 'm'.freeze
+    MULTILINE_VALUE = 'm'
 
     # Newline constant.
     #
     # @since 3.2.6
-    NEWLINE_VALUE = 's'.freeze
+    NEWLINE_VALUE = 's'
 
     # Ruby multiline constant.
     #
     # @since 3.2.6
     #
     # @deprecated Will be removed in 5.0
-    RUBY_MULTILINE_VALUE = 'ms'.freeze
+    RUBY_MULTILINE_VALUE = 'ms'
 
     # Get the regexp as JSON hash data.
     #

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -27,7 +27,7 @@ module BSON
     # A regular expression is type 0x0B in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(11.chr.b)
+    BSON_TYPE = ::String.new(11.chr, encoding: BINARY).freeze
 
     # Extended value constant.
     #

--- a/lib/bson/registry.rb
+++ b/lib/bson/registry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/specialized.rb
+++ b/lib/bson/specialized.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -27,7 +27,7 @@ module BSON
     # A string is type 0x02 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(2.chr.b)
+    BSON_TYPE = ::String.new(2.chr, encoding: BINARY).freeze
 
     # Regex for matching illegal BSON keys.
     #

--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,12 +27,12 @@ module BSON
     # A string is type 0x02 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 2.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(2.chr.b)
 
     # Regex for matching illegal BSON keys.
     #
     # @since 4.1.0
-    ILLEGAL_KEY = /(\A[$])|(\.)/.freeze
+    ILLEGAL_KEY = /(\A[$])|(\.)/
 
     # Get the string as encoded BSON.
     #

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -29,7 +29,7 @@ module BSON
     # A symbol is type 0x0E in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(14.chr.b)
+    BSON_TYPE = ::String.new(14.chr, encoding: BINARY).freeze
 
     # Symbols are serialized as strings as symbols are now removed from the
     # BSON specification. Therefore the bson_type when serializing must be a

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +29,7 @@ module BSON
     # A symbol is type 0x0E in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 14.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(14.chr.b)
 
     # Symbols are serialized as strings as symbols are now removed from the
     # BSON specification. Therefore the bson_type when serializing must be a

--- a/lib/bson/time.rb
+++ b/lib/bson/time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +40,7 @@ module BSON
     # A time is type 0x09 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 9.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(9.chr.b)
 
     # Get the time as encoded BSON.
     #

--- a/lib/bson/time.rb
+++ b/lib/bson/time.rb
@@ -40,7 +40,7 @@ module BSON
     # A time is type 0x09 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(9.chr.b)
+    BSON_TYPE = ::String.new(9.chr, encoding: BINARY).freeze
 
     # Get the time as encoded BSON.
     #

--- a/lib/bson/time_with_zone.rb
+++ b/lib/bson/time_with_zone.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2018-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -27,7 +27,7 @@ module BSON
     # A timestamp is type 0x11 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(17.chr.b)
+    BSON_TYPE = ::String.new(17.chr, encoding: BINARY).freeze
 
     # Error message if an object other than a Timestamp is compared with this object.
     #

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,12 +27,12 @@ module BSON
     # A timestamp is type 0x11 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 17.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(17.chr.b)
 
     # Error message if an object other than a Timestamp is compared with this object.
     #
     # @since 4.3.0
-    COMPARISON_ERROR_MESSAGE = 'comparison of %s with Timestamp failed'.freeze
+    COMPARISON_ERROR_MESSAGE = 'comparison of %s with Timestamp failed'
 
     # @!attribute seconds
     #   @return [ Integer ] The number of seconds.

--- a/lib/bson/true_class.rb
+++ b/lib/bson/true_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +26,7 @@ module BSON
     # A true value in the BSON spec is 0x01.
     #
     # @since 2.0.0
-    TRUE_BYTE = 1.chr.force_encoding(BINARY).freeze
+    TRUE_BYTE = -(1.chr.b)
 
     # The BSON type for true values is the general boolean type of 0x08.
     #

--- a/lib/bson/true_class.rb
+++ b/lib/bson/true_class.rb
@@ -26,7 +26,7 @@ module BSON
     # A true value in the BSON spec is 0x01.
     #
     # @since 2.0.0
-    TRUE_BYTE = -(1.chr.b)
+    TRUE_BYTE = ::String.new(1.chr, encoding: BINARY).freeze
 
     # The BSON type for true values is the general boolean type of 0x08.
     #

--- a/lib/bson/undefined.rb
+++ b/lib/bson/undefined.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +27,7 @@ module BSON
     # Undefined is type 0x06 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = 6.chr.force_encoding(BINARY).freeze
+    BSON_TYPE = -(6.chr.b)
 
     # Determine if undefined is equal to another object.
     #

--- a/lib/bson/undefined.rb
+++ b/lib/bson/undefined.rb
@@ -27,7 +27,7 @@ module BSON
     # Undefined is type 0x06 in the BSON spec.
     #
     # @since 2.0.0
-    BSON_TYPE = -(6.chr.b)
+    BSON_TYPE = ::String.new(6.chr, encoding: BINARY).freeze
 
     # Determine if undefined is equal to another object.
     #

--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,5 +14,5 @@
 # limitations under the License.
 
 module BSON
-  VERSION = "4.12.1".freeze
+  VERSION = "4.12.1"
 end


### PR DESCRIPTION
1/ freezing numeric constants has no effect
2/ regexes are already frozen
3/ freeze strings via frozen_string_literal pragma instead of freezing them explicitly