### PR TITLE
RUBY-2734 Prohibit embedded null bytes in strings used as BSON::Document hash keys, regexps and regexp options

### DIFF
--- a/lib/bson/error.rb
+++ b/lib/bson/error.rb
@@ -25,9 +25,9 @@ module BSON
     end
 
     # Exception raised when there is an invalid argument passed into the
-    # constructor of regexp object. This includes when the argument contians
+    # constructor of regexp object. This includes when the argument contains
     # a null byte.
-    class RegexpArgumentError < Error
+    class InvalidRegexpPattern < Error
     end
   end
 end

--- a/lib/bson/error.rb
+++ b/lib/bson/error.rb
@@ -23,5 +23,11 @@ module BSON
     # itself to BSON.
     class UnserializableClass < Error
     end
+
+    # Exception raised when there is an invalid argument passed into the
+    # constructor of regexp object. This includes when the argument contians
+    # a null byte.
+    class RegexpArgumentError < Error
+    end
   end
 end

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -363,7 +363,7 @@ module BSON
     module_function def map_hash(hash, **options)
       ::Hash[hash.map do |key, value|
         if key.include? NULL_BYTE
-          raise Error::ExtJSONParseError, "Hash key cannot contian a null byte: #{key}"
+          raise Error::ExtJSONParseError, "Hash key cannot contain a null byte: #{key}"
         end
         [key, parse_obj(value, **options)]
       end]

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -362,6 +362,9 @@ module BSON
 
     module_function def map_hash(hash, **options)
       ::Hash[hash.map do |key, value|
+        if key.include? NULL_BYTE
+          raise Error::ExtJSONParseError, "Hash key cannot contian a null byte: #{key}"
+        end
         [key, parse_obj(value, **options)]
       end]
     end

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -155,9 +155,9 @@ module BSON
       # @since 3.0.0
       def initialize(pattern, options = '')
         if pattern.include? NULL_BYTE
-          raise Error::ExtJSONParseError, "Regex pattern cannot contian a null byte: #{key}"
+          raise Error::RegexpArgumentError, "Regexp pattern cannot contain a null byte: #{key}"
         elsif options.is_a?(String) && options.include?(NULL_BYTE)
-          raise Error::ExtJSONParseError, "Regex options cannot contian a null byte: #{key}"
+          raise Error::RegexpArgumentError, "Regexp options cannot contain a null byte: #{key}"
         end
 
         @pattern = pattern

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -155,9 +155,9 @@ module BSON
       # @since 3.0.0
       def initialize(pattern, options = '')
         if pattern.include? NULL_BYTE
-          raise Error::RegexpArgumentError, "Regexp pattern cannot contain a null byte: #{key}"
+          raise Error::InvalidRegexpPattern, "Regexp pattern cannot contain a null byte: #{key}"
         elsif options.is_a?(String) && options.include?(NULL_BYTE)
-          raise Error::RegexpArgumentError, "Regexp options cannot contain a null byte: #{key}"
+          raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{key}"
         end
 
         @pattern = pattern

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -156,7 +156,7 @@ module BSON
       def initialize(pattern, options = '')
         if pattern.include? NULL_BYTE
           raise Error::ExtJSONParseError, "Regex pattern cannot contian a null byte: #{key}"
-        elsif options.include? NULL_BYTE
+        elsif options.is_a?(String) && options.include?(NULL_BYTE)
           raise Error::ExtJSONParseError, "Regex options cannot contian a null byte: #{key}"
         end
 

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -154,6 +154,12 @@ module BSON
       #
       # @since 3.0.0
       def initialize(pattern, options = '')
+        if pattern.include? NULL_BYTE
+          raise Error::ExtJSONParseError, "Regex pattern cannot contian a null byte: #{key}"
+        elsif options.include? NULL_BYTE
+          raise Error::ExtJSONParseError, "Regex options cannot contian a null byte: #{key}"
+        end
+
         @pattern = pattern
         @options = options
       end

--- a/spec/spec_tests/data/corpus/document.json
+++ b/spec/spec_tests/data/corpus/document.json
@@ -31,6 +31,10 @@
         {
             "description": "Invalid subdocument: bad string length in field",
             "bson": "1C00000003666F6F001200000002626172000500000062617A000000"
+        },
+        {
+            "description": "Null byte in sub-document key",
+            "bson": "150000000378000D00000010610000010000000000"
         }
     ]
 }

--- a/spec/spec_tests/data/corpus/regex.json
+++ b/spec/spec_tests/data/corpus/regex.json
@@ -54,11 +54,11 @@
     ],
     "decodeErrors": [
         {
-            "description": "embedded null in pattern",
+            "description": "Null byte in pattern string",
             "bson": "0F0000000B610061006300696D0000"
         },
         {
-            "description": "embedded null in flags",
+            "description": "Null byte in flags string",
             "bson": "100000000B61006162630069006D0000"
         }
     ]

--- a/spec/spec_tests/data/corpus/top.json
+++ b/spec/spec_tests/data/corpus/top.json
@@ -60,6 +60,10 @@
         {
             "description": "Document truncated mid-key",
             "bson": "1200000002666F"
+        },
+        {
+            "description": "Null byte in document key",
+            "bson": "0D000000107800000100000000"
         }
     ],
     "parseErrors": [
@@ -230,7 +234,22 @@
         {
             "description": "Bad DBpointer (extra field)",
             "string": "{\"a\": {\"$dbPointer\": {\"a\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"56e1fc72e0c917e9c4714161\"}, \"c\": {\"$numberInt\": \"2\"}, \"$ref\": \"b\"}}}"
+        },
+        {
+            "description" : "Null byte in document key",
+            "string" : "{\"a\\u0000\": 1 }"
+        },
+        {
+            "description" : "Null byte in sub-document key",
+            "string" : "{\"a\" : {\"b\\u0000\": 1 }}"
+        },
+        {
+            "description": "Null byte in $regularExpression pattern",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\\u0000\", \"options\" : \"i\"}}}"
+        },
+        {
+            "description": "Null byte in $regularExpression options",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\", \"options\" : \"i\\u0000\"}}}"
         }
-
     ]
 }


### PR DESCRIPTION
After adding the tests I noticed that some of them failed, so I went ahead and attempted to implement my own solution.
Before this patch, the following case:
```
{
  "description" : "Null byte in document key",
  "string" : "\{\"a\\u0000\": 1 }"
}
```
Was being parsed as:
```
{ "a\u0000" => 1 } 
```
which is not working as intended. 

We expect it to raise an exception if there's a null byte in the key and this patch fixes that.