### PR TITLE
RUBY-2852 fix error where driver fails on integer key

### DIFF
--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -363,7 +363,7 @@ module BSON
 
     module_function def map_hash(hash, **options)
       ::Hash[hash.map do |key, value|
-        if key.to_s.include? NULL_BYTE
+        if (key.is_a?(String) || key.is_a?(Symbol)) && key.to_s.include?(NULL_BYTE)
           raise Error::ExtJSONParseError, "Hash key cannot contain a null byte: #{key}"
         end
         [key, parse_obj(value, **options)]

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -363,7 +363,7 @@ module BSON
 
     module_function def map_hash(hash, **options)
       ::Hash[hash.map do |key, value|
-        if key.include? NULL_BYTE
+        if key.to_s.include?(NULL_BYTE)
           raise Error::ExtJSONParseError, "Hash key cannot contain a null byte: #{key}"
         end
         [key, parse_obj(value, **options)]

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -363,7 +363,7 @@ module BSON
 
     module_function def map_hash(hash, **options)
       ::Hash[hash.map do |key, value|
-        if key.to_s.include?(NULL_BYTE)
+        if key.to_s.include? NULL_BYTE
           raise Error::ExtJSONParseError, "Hash key cannot contain a null byte: #{key}"
         end
         [key, parse_obj(value, **options)]

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -157,7 +157,7 @@ module BSON
       def initialize(pattern, options = '')
         if pattern.include? NULL_BYTE
           raise Error::InvalidRegexpPattern, "Regexp pattern cannot contain a null byte: #{key}"
-        elsif options.to_s.include?(NULL_BYTE)
+        elsif options.to_s.include? NULL_BYTE
           raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{key}"
         end
 

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -156,9 +156,9 @@ module BSON
       # @since 3.0.0
       def initialize(pattern, options = '')
         if pattern.include? NULL_BYTE
-          raise Error::InvalidRegexpPattern, "Regexp pattern cannot contain a null byte: #{key}"
+          raise Error::InvalidRegexpPattern, "Regexp pattern cannot contain a null byte: #{pattern}"
         elsif options.to_s.include? NULL_BYTE
-          raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{key}"
+          raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{options}"
         end
 
         @pattern = pattern

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -157,7 +157,7 @@ module BSON
       def initialize(pattern, options = '')
         if pattern.include? NULL_BYTE
           raise Error::InvalidRegexpPattern, "Regexp pattern cannot contain a null byte: #{key}"
-        elsif options.is_a?(String) && options.include?(NULL_BYTE)
+        elsif options.to_s.include?(NULL_BYTE)
           raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{key}"
         end
 

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -155,10 +155,14 @@ module BSON
       #
       # @since 3.0.0
       def initialize(pattern, options = '')
-        if pattern.include? NULL_BYTE
+        if pattern.include?(NULL_BYTE)
           raise Error::InvalidRegexpPattern, "Regexp pattern cannot contain a null byte: #{pattern}"
-        elsif options.to_s.include? NULL_BYTE
-          raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{options}"
+        elsif options.is_a?(String) || options.is_a?(Symbol)
+          if options.to_s.include?(NULL_BYTE)
+            raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{options}"
+          end
+        elsif !options.is_a?(Integer)
+          raise ArgumentError, "Regexp options must be a String, Symbol, or Integer"
         end
 
         @pattern = pattern

--- a/spec/bson/ext_json_parse_spec.rb
+++ b/spec/bson/ext_json_parse_spec.rb
@@ -162,7 +162,7 @@ describe "BSON::ExtJSON.parse" do
 
     context 'when it contains a string key with a null byte' do
       let(:input) do
-        { "\x00" => 1 }
+        { "key\x00" => 1 }
       end
 
       it 'raises an exception' do
@@ -174,7 +174,7 @@ describe "BSON::ExtJSON.parse" do
 
     context 'when it contains a symbol key with a null byte' do
       let(:input) do
-        { "\x00".to_sym => 1 }
+        { "key\x00".to_sym => 1 }
       end
 
       it 'raises an exception' do

--- a/spec/bson/ext_json_parse_spec.rb
+++ b/spec/bson/ext_json_parse_spec.rb
@@ -160,7 +160,7 @@ describe "BSON::ExtJSON.parse" do
       end
     end
 
-    context 'when it contains a string key with a null-byte' do
+    context 'when it contains a string key with a null byte' do
       let(:input) do
         { "\x00" => 1 }
       end
@@ -172,7 +172,7 @@ describe "BSON::ExtJSON.parse" do
       end
     end
 
-    context 'when it contains a symbol key with a null-byte' do
+    context 'when it contains a symbol key with a null byte' do
       let(:input) do
         { "\x00".to_sym => 1 }
       end

--- a/spec/bson/ext_json_parse_spec.rb
+++ b/spec/bson/ext_json_parse_spec.rb
@@ -148,6 +148,7 @@ describe "BSON::ExtJSON.parse" do
     end
 
     let(:parsed) { BSON::ExtJSON.parse_obj(input, mode: mode) }
+    let(:mode) { :bson }
 
     context 'when mode is invalid' do
       let(:mode) { :foo }
@@ -156,6 +157,42 @@ describe "BSON::ExtJSON.parse" do
         lambda do
           parsed
         end.should raise_error(ArgumentError, /Invalid value for :mode option/)
+      end
+    end
+
+    context 'when it contains a string key with a null-byte' do
+      let(:input) do
+        { "\x00" => 1 }
+      end
+
+      it 'raises an exception' do
+        lambda do
+          parsed
+        end.should raise_error(BSON::Error::ExtJSONParseError, /Hash key cannot contain a null byte/)
+      end
+    end
+
+    context 'when it contains a symbol key with a null-byte' do
+      let(:input) do
+        { "\x00".to_sym => 1 }
+      end
+
+      it 'raises an exception' do
+        lambda do
+          parsed
+        end.should raise_error(BSON::Error::ExtJSONParseError, /Hash key cannot contain a null byte/)
+      end
+    end
+
+    context 'when it contains an integer key' do
+      let(:input) do
+        { 0 => 1 }
+      end
+
+      it 'does not raises an exception' do
+        lambda do
+          parsed
+        end.should_not raise_error
       end
     end
   end

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -127,6 +127,33 @@ describe Regexp do
           expect(result).to eq(obj)
         end
       end
+
+      context "when the regexp options contains a null byte" do
+
+        let(:regexp) do
+          Regexp::Raw.new("pattern", "\x00")
+        end
+
+        it "raises an error" do
+          expect do
+            regexp
+          end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp options cannot contain a null byte: .*/)
+        end
+      end
+    end
+
+    context "when the pattern contains a null byte" do
+
+      let(:regexp) do
+        Regexp::Raw.new("pattern\x00", "options")
+      end
+
+      it "raises an error" do
+        expect do
+          regexp
+        end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp pattern cannot contain a null byte: .*/)
+      end
     end
   end
+  context
 end

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -131,13 +131,13 @@ describe Regexp do
       context "when the regexp options contains a null byte" do
 
         let(:regexp) do
-          Regexp::Raw.new("pattern", "\x00")
+          Regexp::Raw.new("pattern", "options\x00")
         end
 
         it "raises an error" do
           expect do
             regexp
-          end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp options cannot contain a null byte: .*/)
+          end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp options cannot contain a null byte/)
         end
       end
     end
@@ -151,9 +151,8 @@ describe Regexp do
       it "raises an error" do
         expect do
           regexp
-        end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp pattern cannot contain a null byte: .*/)
+        end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp pattern cannot contain a null byte/)
       end
     end
   end
-  context
 end

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -140,6 +140,32 @@ describe Regexp do
           end.to raise_error(BSON::Error::InvalidRegexpPattern, /Regexp options cannot contain a null byte/)
         end
       end
+
+      context "when the regexp options is an integer" do
+
+        let(:regexp) do
+          Regexp::Raw.new("pattern", 1)
+        end
+
+        it "doesn't raise an error" do
+          expect do
+            regexp
+          end.to_not raise_error
+        end
+      end
+
+      context "when the regexp options is an invalid type" do
+
+        let(:regexp) do
+          Regexp::Raw.new("pattern", [2])
+        end
+
+        it "raises an error" do
+          expect do
+            regexp
+          end.to raise_error(ArgumentError, /Regexp options must be a String, Symbol, or Integer/)
+        end
+      end
     end
 
     context "when the pattern contains a null byte" do


### PR DESCRIPTION
Evergreen patch for Ruby Driver with this branch of BSON ruby: https://spruce.mongodb.com/version/61ba2a57a4cf473d0db59180/tasks

The JRuby one still fails but I think it's not getting the right BSON ruby. I think that failure will be gone once this is merged into master


