### PR TITLE
RUBY-2861 add documentation for the loss of trailing zeroes

### DIFF
--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -547,6 +547,12 @@ follows:
   deserializing from BSON. ``BigDecimal``, however, does not maintain trailing
   zeroes and therefore using ``BigDecimal`` may result in a lack of precision.
 
+.. note::
+
+  In BSON 5.0 ``BSON::Decimal128`` will be deserialized into ``BigDecimal`` by
+  default. In order to have ``BSON::Decimal128`` be deserialized into
+  ``BigDecimal``, the ``mode: :bson`` option can be set on ``from_bson``.
+
 ``Symbol``
 ----------
 

--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -550,8 +550,9 @@ follows:
 .. note::
 
   In BSON 5.0, ``BSON::Decimal128`` will be deserialized into ``BigDecimal`` by
-  default. In order to have ``BSON::Decimal128`` be deserialized into
-  ``BSON::Decimal128``, the ``mode: :bson`` option can be set on ``from_bson``.
+  default. In order to have ``BSON::Decimal128`` values in BSON documents
+  deserialized into ``BSON::Decimal128``, the ``mode: :bson`` option can be set
+  on ``from_bson``.
 
 ``Symbol``
 ----------

--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -543,6 +543,10 @@ follows:
   ``BigDecimal`` is not. All signed ``NaN`` values that are deserialized into
   ``BigDecimal`` instances will be unsigned.
 
+- ``BSON::Decimal128`` maintains trailing zeroes when serializing to and
+  deserializing from BSON. ``BigDecimal``, however, does not maintain trailing
+  zeroes and therefore using ``BigDecimal`` may result in a lack of precision.
+
 ``Symbol``
 ----------
 

--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -549,9 +549,9 @@ follows:
 
 .. note::
 
-  In BSON 5.0 ``BSON::Decimal128`` will be deserialized into ``BigDecimal`` by
+  In BSON 5.0, ``BSON::Decimal128`` will be deserialized into ``BigDecimal`` by
   default. In order to have ``BSON::Decimal128`` be deserialized into
-  ``BigDecimal``, the ``mode: :bson`` option can be set on ``from_bson``.
+  ``BSON::Decimal128``, the ``mode: :bson`` option can be set on ``from_bson``.
 
 ``Symbol``
 ----------


### PR DESCRIPTION
I added the note about the future functionality of BigDecimal into this PR. 
<img width="841" alt="Screen Shot 2022-01-04 at 11 55 39 AM" src="https://user-images.githubusercontent.com/8226355/148095230-9857d90b-d3b6-4f29-a8c0-c571f31a4b14.png">

