### PR TITLE
RUBY-2867 Change Decimal128 to deserialize to BigDecimal by default

### DIFF
--- a/docs/tutorials/bson-v4.txt
+++ b/docs/tutorials/bson-v4.txt
@@ -549,7 +549,7 @@ follows:
 
 .. note::
 
-  In BSON 5.0, ``BSON::Decimal128`` will be deserialized into ``BigDecimal`` by
+  In BSON 5.0, ``BSON::Decimal128`` is deserialized into ``BigDecimal`` by
   default. In order to have ``BSON::Decimal128`` values in BSON documents
   deserialized into ``BSON::Decimal128``, the ``mode: :bson`` option can be set
   on ``from_bson``.

--- a/ext/bson/read.c
+++ b/ext/bson/read.c
@@ -82,21 +82,17 @@ VALUE pvt_read_field(byte_buffer_t *b, VALUE rb_buffer, uint8_t type, int argc, 
     {
       VALUE klass = rb_funcall(rb_bson_registry, rb_intern("get"), 1, INT2FIX(type));
       VALUE value;
-      if (argc > 0) {
-        VALUE *call_args = calloc(argc + 1, sizeof(VALUE));
-        if (call_args == NULL) {
-          rb_raise(rb_eNoMemError, "Stack memory allocation failed, argument list too long?");
-        }
+      if (argc > 1) {
+        rb_raise(rb_eArgError, "At most one argument is allowed");
+      } else if (argc > 0) {
+        VALUE call_args[2];
         call_args[0] = rb_buffer;
-        memcpy(&call_args[1], argv, argc * sizeof(VALUE));
+        Check_Type(argv[0], T_HASH);
+        call_args[1] = argv[0];
 #ifdef RB_PASS_KEYWORDS /* Ruby 2.7+ */
-        /* Here we specify that the last argument is a keyword hash, but */
-        /* we haven't verified this for the input arguments. */
-        /* This might fail (or perhaps even crash) if the last argument is, */
-        /* for example, not a hash at all. */
-        value = rb_funcallv_kw(klass, rb_intern("from_bson"), argc + 1, call_args, RB_PASS_KEYWORDS);
+        value = rb_funcallv_kw(klass, rb_intern("from_bson"), 2, call_args, RB_PASS_KEYWORDS);
 #else /* Ruby 2.6 and below */
-        value = rb_funcallv(klass, rb_intern("from_bson"), argc + 1, call_args);
+        value = rb_funcallv(klass, rb_intern("from_bson"), 2, call_args);
 #endif
       } else {
         value = rb_funcall(klass, rb_intern("from_bson"), 1, rb_buffer);

--- a/ext/bson/read.c
+++ b/ext/bson/read.c
@@ -89,11 +89,15 @@ VALUE pvt_read_field(byte_buffer_t *b, VALUE rb_buffer, uint8_t type, int argc, 
         }
         call_args[0] = rb_buffer;
         memcpy(&call_args[1], argv, argc * sizeof(VALUE));
+#ifdef RB_PASS_KEYWORDS /* Ruby 2.7+ */
         /* Here we specify that the last argument is a keyword hash, but */
         /* we haven't verified this for the input arguments. */
         /* This might fail (or perhaps even crash) if the last argument is, */
         /* for example, not a hash at all. */
         value = rb_funcallv_kw(klass, rb_intern("from_bson"), argc + 1, call_args, RB_PASS_KEYWORDS);
+#else /* Ruby 2.6 and below */
+        value = rb_funcallv(klass, rb_intern("from_bson"), argc + 1, call_args);
+#endif
       } else {
         value = rb_funcall(klass, rb_intern("from_bson"), 1, rb_buffer);
       }

--- a/lib/bson/big_decimal.rb
+++ b/lib/bson/big_decimal.rb
@@ -58,7 +58,6 @@ module BSON
       # @return [ BigDecimal | BSON::Decimal128 ] The decimal object.
       def from_bson(buffer, **options)
         dec128 = Decimal128.from_bson(buffer, **options)
-        byebug
         if options[:mode] == :bson
           dec128
         else

--- a/lib/bson/big_decimal.rb
+++ b/lib/bson/big_decimal.rb
@@ -21,7 +21,7 @@ module BSON
   # @see http://bsonspec.org/#/specification
   module BigDecimal
 
-    # BigDecimals are serialized as Decimal128s under the hood. A Decimal128 
+    # BigDecimals are serialized as Decimal128s under the hood. A Decimal128
     # is type 0x13 in the BSON spec.
     BSON_TYPE = ::String.new(19.chr, encoding: BINARY).freeze
 
@@ -45,7 +45,8 @@ module BSON
 
     module ClassMethods
 
-      # Deserialize the BigDecimal from raw BSON bytes.
+      # Deserialize the BigDecimal from raw BSON bytes. If the :mode option
+      # is set to BSON, this will return a BSON::Decimal128
       #
       # @example Get the BigDecimal from BSON.
       #   BigDecimal.from_bson(bson)
@@ -54,11 +55,20 @@ module BSON
       #
       # @option options [ nil | :bson ] :mode Decoding mode to use.
       #
-      # @return [ BigDecimal ] The decimal object.
+      # @return [ BigDecimal | BSON::Decimal128 ] The decimal object.
       def from_bson(buffer, **options)
-        Decimal128.from_bson(buffer, **options).to_big_decimal
+        dec128 = Decimal128.from_bson(buffer, **options)
+        byebug
+        if options[:mode] == :bson
+          dec128
+        else
+          dec128.to_big_decimal
+        end
       end
     end
+
+    # Register this type when the module is loaded.
+    Registry.register(BSON_TYPE, ::BigDecimal)
   end
 
   # Enrich the core BigDecimal class with this module.

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -119,6 +119,11 @@ module BSON
       end
     end
 
+    # Get the BSON type for Decimal128.
+    def bson_type
+      BSON_TYPE
+    end
+
     # Get the decimal128 as its raw BSON data.
     #
     # @example Get the raw bson bytes in a buffer.
@@ -343,7 +348,5 @@ module BSON
         'The value contains too much precision for Decimal128 representation'
       end
     end
-
-    Registry.register(BSON_TYPE, self)
   end
 end

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -14,7 +14,7 @@
 
 require "spec_helper"
 
-describe BSON::BigDecimal do
+describe BigDecimal do
 
   describe '#from_bson' do
     shared_examples_for 'a BSON::BigDecimal deserializer' do
@@ -311,6 +311,17 @@ describe BSON::BigDecimal do
       let(:argument) { "-1234567890123456789012345678901234" }
 
       it_behaves_like 'a BSON::BigDecimal round trip'
+    end
+  end
+
+  context "when the class is loaded" do
+
+    let(:registered) do
+      BSON::Registry.get(described_class::BSON_TYPE, 'field')
+    end
+
+    it "registers the type" do
+      expect(registered).to eq(described_class)
     end
   end
 end

--- a/spec/bson/decimal128_spec.rb
+++ b/spec/bson/decimal128_spec.rb
@@ -46,7 +46,7 @@ describe BSON::Decimal128 do
       end
 
       let(:from_bson) do
-        described_class.from_bson(buffer)
+        described_class.from_bson(buffer, mode: :bson)
       end
 
       let(:expected_bson) do
@@ -344,7 +344,7 @@ describe BSON::Decimal128 do
       end
 
       let(:decimal128) do
-        BSON::Document.from_bson(buffer)['d']
+        BSON::Document.from_bson(buffer, mode: :bson)['d']
       end
 
       let(:object_from_string) do
@@ -1616,17 +1616,6 @@ describe BSON::Decimal128 do
       end
 
       it_behaves_like 'a decimal128 convertible to a Ruby BigDecimal'
-    end
-  end
-
-  context "when the class is loaded" do
-
-    let(:registered) do
-      BSON::Registry.get(described_class::BSON_TYPE, 'field')
-    end
-
-    it "registers the type" do
-      expect(registered).to eq(described_class)
     end
   end
 end

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -270,8 +270,28 @@ describe Hash do
         end.to_not raise_error
       end
 
-      it 'deserializes as a BSON::Decimal128' do
-        expect(from_bson).to eq({"x" => BSON::Decimal128.new('1')})
+      it 'deserializes as a BigDecimal' do
+        expect(from_bson).to eq({"x" => BigDecimal(1)})
+      end
+    end
+
+    context 'when deserializing round-tripping a Decimal128' do
+      let(:to_bson) do
+        {x:BSON::Decimal128.new('1')}.to_bson
+      end
+
+      let(:from_bson) do
+        Hash.from_bson(to_bson)
+      end
+
+      it 'doesn\'t raise on serialization' do
+        expect do
+          to_bson
+        end.to_not raise_error
+      end
+
+      it 'deserializes as a BigDecimal' do
+        expect(from_bson).to eq({"x" => BigDecimal(1)})
       end
     end
   end
@@ -348,7 +368,7 @@ describe Hash do
       it 'works' do
         expect do
           hash.to_bson
-        end.not_to raise_error
+        end.to_not raise_error
       end
     end
   end
@@ -395,6 +415,34 @@ describe Hash do
 
       it 'overwrites first value with second value' do
         expect(doc).to eq({ 'foo' => :bar })
+      end
+    end
+
+    context 'when deserializing a hash with a BigDecimal' do
+      let(:to_bson) do
+        {x: BigDecimal('1')}.to_bson
+      end
+
+      context 'when it has mode: :bson' do
+
+        let(:from_bson) do
+          Hash.from_bson(to_bson, mode: :bson)
+        end
+
+        it 'deserializes as a BigDecimal' do
+          expect(from_bson).to eq({"x" => BSON::Decimal128.new('1')})
+        end
+      end
+
+      context 'when it doesn\'t have mode: :bson' do
+
+        let(:from_bson) do
+          Hash.from_bson(to_bson)
+        end
+
+        it 'deserializes as a BigDecimal' do
+          expect(from_bson).to eq({"x" => BigDecimal(1)})
+        end
       end
     end
   end

--- a/spec/runners/common_driver.rb
+++ b/spec/runners/common_driver.rb
@@ -340,7 +340,7 @@ module BSON
       def decoded_document
         @document ||= (data = [ @subject ].pack('H*')
           buffer = BSON::ByteBuffer.new(data)
-          BSON::Document.from_bson(buffer))
+          BSON::Document.from_bson(buffer, mode: :bson))
       end
     end
   end


### PR DESCRIPTION
This PR is observing errors because of a bug where options are not passed to recursive calls to `#from_bson`. Investigating this further. 

EDIT: Now I'm observing errors in ruby 3.0