### PR TITLE
RUBY-2777 remove support for integer options for Regexp::Raw constructor

### DIFF
--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -147,11 +147,8 @@ module BSON
       #   Raw.new(pattern, options)
       #
       # @param [ String ] pattern The regular expression pattern.
-      # @param [ String, Integer ] options The options.
-      #
-      # @note The ability to specify options as an Integer is deprecated.
-      #  Please specify options as a String. The ability to pass options as
-      #  as Integer will be removed in version 5.0.0.
+      # @param [ String ] options The options.
+
       #
       # @since 3.0.0
       def initialize(pattern, options = '')
@@ -161,7 +158,7 @@ module BSON
           if options.to_s.include?(NULL_BYTE)
             raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{options}"
           end
-        elsif !options.is_a?(Integer)
+        else
           raise ArgumentError, "Regexp options must be a String, Symbol, or Integer"
         end
 

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -159,7 +159,7 @@ module BSON
             raise Error::InvalidRegexpPattern, "Regexp options cannot contain a null byte: #{options}"
           end
         else
-          raise ArgumentError, "Regexp options must be a String, Symbol, or Integer"
+          raise ArgumentError, "Regexp options must be a String or Symbol"
         end
 
         @pattern = pattern

--- a/spec/bson/raw_spec.rb
+++ b/spec/bson/raw_spec.rb
@@ -84,19 +84,10 @@ describe Regexp::Raw do
 
         let(:options) { ::Regexp::EXTENDED }
 
-        it "sets the options on the raw regex" do
-          expect(object.options). to eq(options)
-        end
-
-        context "When the raw regexp is compiled" do
-
-          let(:regexp) do
-            object.compile
-          end
-
-          it "sets the options on the compiled regexp object" do
-            expect(regexp.options).to eq(options)
-          end
+        it "raises an error" do
+          expect do
+            object
+          end.to raise_error(ArgumentError, /Regexp options must be a String or Symbol/)
         end
       end
 
@@ -320,8 +311,10 @@ describe Regexp::Raw do
         let(:options) { ::Regexp::EXTENDED }
         let(:bson) { "#{pattern}#{BSON::NULL_BYTE}mx#{BSON::NULL_BYTE}" }
 
-        it "sets the option on the serialized bson object" do
-          expect(serialized).to eq(bson)
+        it "raises an error" do
+          expect do
+            serialized
+          end.to raise_error(ArgumentError, /Regexp options must be a String or Symbol/)
         end
       end
 

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -147,10 +147,10 @@ describe Regexp do
           Regexp::Raw.new("pattern", 1)
         end
 
-        it "doesn't raise an error" do
+        it "raises an error" do
           expect do
             regexp
-          end.to_not raise_error
+          end.to raise_error(ArgumentError, /Regexp options must be a String or Symbol/)
         end
       end
 
@@ -163,7 +163,7 @@ describe Regexp do
         it "raises an error" do
           expect do
             regexp
-          end.to raise_error(ArgumentError, /Regexp options must be a String, Symbol, or Integer/)
+          end.to raise_error(ArgumentError, /Regexp options must be a String or Symbol/)
         end
       end
     end

--- a/spec/spec_tests/data/corpus/top.json
+++ b/spec/spec_tests/data/corpus/top.json
@@ -77,11 +77,11 @@
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"$options\" : \"\"}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"options\" : \"\"}}}"
         },
         {
             "description": "Bad $regularExpression (options are number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"$options\" : 0}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"options\" : 0}}}"
         },
         {
             "description" : "Bad $regularExpression (missing pattern field)",


### PR DESCRIPTION
Since master is 5.0, I think we can remove support for integer options in Regexp::Raw constructor. This allows me to fix the bson corpus tests.

