### PR TITLE
RUBY-3137 Use SecureRandom to initialize ObjectId counter

### DIFF
--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require "digest/md5"
+require "securerandom"
 require "socket"
 require "thread"
 
@@ -351,7 +352,7 @@ module BSON
       #
       # @since 2.0.0
       def initialize
-        @counter = rand(0x1000000)
+        @counter = ::SecureRandom.rand(0x1000000)
         @machine_id = Digest::MD5.digest(Socket.gethostname).unpack1("N")
         @mutex = Mutex.new
       end


### PR DESCRIPTION
Hello,
I am auditing some MongoDB Ruby code and found that `ObjectId` uses `Kernel.rand` to initialize the counter.
While `Kernel.rand` differs from implementation to implementation, it is likely seeded by at least the PID of the Ruby process.

In the `ObjectId` use case, since we already used `PID` in the tuple, we want to make sure other values in the tuple are independent from the `PID` as much as possible.

I know it might not have a concrete downside in practice, but just to be on the safe side, I would recommend initializing the counter with `SecureRandom` instead; what do you say?