### PR TITLE
RUBY-1806 change all errors to subclass BSON::Error

### DIFF
--- a/ext/bson/init.c
+++ b/ext/bson/init.c
@@ -60,7 +60,7 @@ void Init_bson_native()
   VALUE rb_digest_class = rb_const_get(rb_cObject, rb_intern("Digest"));
   VALUE rb_md5_class = rb_const_get(rb_digest_class, rb_intern("MD5"));
 
-  rb_bson_illegal_key = rb_const_get(rb_const_get(rb_bson_module, rb_intern("String")),rb_intern("IllegalKey"));
+  rb_bson_illegal_key = rb_const_get(rb_const_get(rb_bson_module, rb_intern("Error")),rb_intern("IllegalKey"));
   rb_gc_register_mark_object(rb_bson_illegal_key);
 
   rb_define_alloc_func(rb_byte_buffer_class, rb_bson_byte_buffer_allocate);
@@ -116,7 +116,7 @@ void Init_bson_native()
   rb_define_method(rb_byte_buffer_class, "get_array", rb_bson_byte_buffer_get_array, -1);
 
   rb_define_method(rb_byte_buffer_class, "get_int32", rb_bson_byte_buffer_get_int32, 0);
-  
+
   /*
    * call-seq:
    *   buffer.get_uint32(buffer) -> Fixnum

--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -27,7 +27,7 @@ module BSON
   #
   # @param [ String ] string The string to create the id from.
   #
-  # @raise [ BSON::ObjectId::Invalid ] If the provided string is invalid.
+  # @raise [ BSON::Error::InvalidObjectId ] If the provided string is invalid.
   #
   # @return [ BSON::ObjectId ] The new object id.
   #

--- a/lib/bson/array.rb
+++ b/lib/bson/array.rb
@@ -68,7 +68,7 @@ module BSON
     #
     # @note This is used for repairing legacy bson data.
     #
-    # @raise [ BSON::ObjectId::Invalid ] If the array is not 12 elements.
+    # @raise [ BSON::Error::InvalidObjectId ] If the array is not 12 elements.
     #
     # @return [ String ] The raw object id bytes.
     #

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -328,42 +328,6 @@ module BSON
       end
     end
 
-    # Raised when providing an invalid type to the Binary.
-    #
-    # @since 2.0.0
-    class InvalidType < RuntimeError
-
-      # @!attribute type
-      #   @return [ Object ] The invalid type.
-      #   @since 2.0.0
-      attr_reader :type
-
-      # Instantiate the new error.
-      #
-      # @example Instantiate the error.
-      #   InvalidType.new(:error)
-      #
-      # @param [ Object ] type The invalid type.
-      #
-      # @since 2.0.0
-      def initialize(type)
-        @type = type
-      end
-
-      # Get the custom error message for the exception.
-      #
-      # @example Get the message.
-      #   error.message
-      #
-      # @return [ String ] The error message.
-      #
-      # @since 2.0.0
-      def message
-        "#{type.inspect} is not a valid binary type. " +
-          "Please use one of #{SUBTYPES.keys.map(&:inspect).join(", ")}."
-      end
-    end
-
     private
 
     # Validate the provided type is a valid type.
@@ -375,11 +339,11 @@ module BSON
     #
     # @param [ Object ] type The provided type.
     #
-    # @raise [ InvalidType ] The the type is invalid.
+    # @raise [ BSON::Error::InvalidBinaryType ] The the type is invalid.
     #
     # @since 2.0.0
     def validate_type!(type)
-      raise InvalidType.new(type) unless SUBTYPES.has_key?(type)
+      raise BSON::Error::InvalidBinaryType.new(type) unless SUBTYPES.has_key?(type)
     end
 
     # Register this type when the module is loaded.

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -116,7 +116,7 @@ module BSON
     # @param [ String, BigDecimal ] object The BigDecimal or String to use for
     #   instantiating a Decimal128.
     #
-    # @raise [ InvalidArgument ] When argument is not a String or BigDecimal.
+    # @raise [ BSON::Error::InvalidDecimal128Argument ] When argument is not a String or BigDecimal.
     #
     # @since 4.2.0
     def initialize(object)
@@ -125,7 +125,7 @@ module BSON
       elsif object.is_a?(BigDecimal)
         set_bits(*Builder::FromBigDecimal.new(object).bits)
       else
-        raise InvalidArgument.new
+        raise Error::InvalidDecimal128Argument.new
       end
     end
 
@@ -242,7 +242,7 @@ module BSON
       #
       # @param [ String ] string The string to parse.
       #
-      # @raise [ BSON::Decimal128::InvalidString ] If the provided string is invalid.
+      # @raise [ BSON::Error:InvalidDecimal128String ] If the provided string is invalid.
       #
       # @return [ BSON::Decimal128 ] The new decimal128.
       #
@@ -266,96 +266,6 @@ module BSON
         decimal = allocate
         decimal.send(:set_bits, low, high)
         decimal
-      end
-    end
-
-    # Raised when trying to create a Decimal128 from an object that is neither a String nor a BigDecimal.
-    #
-    # @api private
-    #
-    # @since 4.2.0
-    class InvalidArgument < ArgumentError
-
-      # The custom error message for this error.
-      #
-      # @since 4.2.0
-      MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'
-
-      # Get the custom error message for the exception.
-      #
-      # @example Get the message.
-      #   error.message
-      #
-      # @return [ String ] The error message.
-      #
-      # @since 4.2.0
-      def message
-        MESSAGE
-      end
-    end
-
-    # Raised when trying to create a Decimal128 from a string with
-    #   an invalid format.
-    #
-    # @api private
-    #
-    # @since 4.2.0
-    class InvalidString < RuntimeError
-
-      # The custom error message for this error.
-      #
-      # @since 4.2.0
-      MESSAGE = 'Invalid string format for creating a Decimal128 object.'
-
-      # Get the custom error message for the exception.
-      #
-      # @example Get the message.
-      #   error.message
-      #
-      # @return [ String ] The error message.
-      #
-      # @since 4.2.0
-      def message
-        MESSAGE
-      end
-    end
-
-    # Raised when the exponent is outside the valid range.
-    #
-    # @since 4.2.0
-    class InvalidRange < RuntimeError
-
-      # The custom error message for this error.
-      #
-      # @since 4.2.0
-      # @deprecated
-      MESSAGE = 'Value out of range for Decimal128 representation.'
-
-      # Get the custom error message for the exception.
-      #
-      # @example Get the message.
-      #   error.message
-      #
-      # @return [ String ] The error message.
-      #
-      # @since 4.2.0
-      def message
-        MESSAGE
-      end
-    end
-
-    # Raised when the significand provided is outside the valid range.
-    #
-    # @note This class derives from InvalidRange for backwards compatibility,
-    #   however when RUBY-1806 is implemented it should be changed to derive
-    #   from the base BSON exception class.
-    class UnrepresentablePrecision < InvalidRange
-
-      # Get the custom error message for the exception.
-      #
-      # @return [ String ] The error message.
-      def message
-        'The value contains too much precision for Decimal128 representation'
       end
     end
   end

--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -86,11 +86,11 @@ module BSON
 
       def validate_range!(exponent, significand)
         unless valid_exponent?(exponent)
-          raise Decimal128::InvalidRange.new
+          raise Error::InvalidDecimal128Range.new
         end
 
         unless valid_significand?(significand)
-          raise Decimal128::UnrepresentablePrecision.new
+          raise Error::UnrepresentablePrecision.new
         end
       end
 
@@ -262,7 +262,7 @@ module BSON
         end
 
         def validate_format!
-          raise BSON::Decimal128::InvalidString.new unless @string =~ VALID_DECIMAL128_STRING_REGEX
+          raise Error::InvalidDecimal128String.new unless @string =~ VALID_DECIMAL128_STRING_REGEX
         end
       end
 

--- a/lib/bson/error.rb
+++ b/lib/bson/error.rb
@@ -1,34 +1,21 @@
 # frozen_string_literal: true
 module BSON
   # Base exception class for all BSON-related errors.
-  #
-  # @note Many existing exceptions raised by bson-ruby do not derive from
-  #   this base class. This will change in the next major version (5.0).
   class Error < StandardError
-
-    # Exception raised when Extended JSON parsing fails.
-    class ExtJSONParseError < Error
-    end
-
-    # Exception raised when decoding BSON and the data contains an
-    # unsupported binary subtype.
-    class UnsupportedBinarySubtype < Error
-    end
-
-    # Exception raised when BSON decoding fails.
-    class BSONDecodeError < Error
-    end
-
-    # Exception raised when serializing an Array or Hash to BSON and an
-    # array or hash element is of a class that does not define how to serialize
-    # itself to BSON.
-    class UnserializableClass < Error
-    end
-
-    # Exception raised when there is an invalid argument passed into the
-    # constructor of regexp object. This includes when the argument contains
-    # a null byte.
-    class InvalidRegexpPattern < Error
-    end
   end
 end
+
+require 'bson/error/bson_decode_error'
+require 'bson/error/ext_json_parse_error'
+require 'bson/error/illegal_key'
+require 'bson/error/invalid_binary_type'
+require 'bson/error/invalid_decimal128_argument'
+require 'bson/error/invalid_decimal128_range'
+require 'bson/error/invalid_decimal128_string'
+require 'bson/error/invalid_key'
+require 'bson/error/invalid_object_id'
+require 'bson/error/invalid_regexp_pattern'
+require 'bson/error/unrepresentable_precision'
+require 'bson/error/unserializable_class'
+require 'bson/error/unsupported_binary_subtype'
+require 'bson/error/unsupported_type'

--- a/lib/bson/error/bson_decode_error.rb
+++ b/lib/bson/error/bson_decode_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Exception raised when BSON decoding fails.
+    class BSONDecodeError < Error
+    end
+  end
+end

--- a/lib/bson/error/ext_json_parse_error.rb
+++ b/lib/bson/error/ext_json_parse_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Exception raised when Extended JSON parsing fails.
+    class ExtJSONParseError < Error
+    end
+  end
+end

--- a/lib/bson/error/illegal_key.rb
+++ b/lib/bson/error/illegal_key.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when validating keys and a key is illegal in MongoDB
+    class IllegalKey < RuntimeError
+
+      # Instantiate the exception.
+      #
+      # @example Instantiate the exception.
+      #   BSON::Error::IllegalKey.new(string)
+      #
+      # @param [ String ] string The illegal string.
+      def initialize(string)
+        super("'#{string}' is an illegal key in MongoDB. Keys may not start with '$' or contain a '.'.")
+      end
+    end
+  end
+end

--- a/lib/bson/error/illegal_key.rb
+++ b/lib/bson/error/illegal_key.rb
@@ -12,6 +12,8 @@ module BSON
       #   BSON::Error::IllegalKey.new(string)
       #
       # @param [ String ] string The illegal string.
+      #
+      # @api private
       def initialize(string)
         super("'#{string}' is an illegal key in MongoDB. Keys may not start with '$' or contain a '.'.")
       end

--- a/lib/bson/error/invalid_binary_type.rb
+++ b/lib/bson/error/invalid_binary_type.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when providing an invalid type to the Binary.
+    #
+    # @since 2.0.0
+    class InvalidBinaryType < Error
+
+      # @return [ Object ] The invalid type.
+      attr_reader :type
+
+      # Instantiate the new error.
+      #
+      # @example Instantiate the error.
+      #   InvalidBinaryType.new(:error)
+      #
+      # @param [ Object ] type The invalid type.
+      def initialize(type)
+        @type = type
+      end
+
+      # Get the custom error message for the exception.
+      #
+      # @example Get the message.
+      #   error.message
+      #
+      # @return [ String ] The error message.
+      def message
+        "#{type.inspect} is not a valid binary type. " +
+          "Please use one of #{BSON::Binary::SUBTYPES.keys.map(&:inspect).join(", ")}."
+      end
+    end
+  end
+end

--- a/lib/bson/error/invalid_binary_type.rb
+++ b/lib/bson/error/invalid_binary_type.rb
@@ -4,8 +4,6 @@ module BSON
   class Error
 
     # Raised when providing an invalid type to the Binary.
-    #
-    # @since 2.0.0
     class InvalidBinaryType < Error
 
       # @return [ Object ] The invalid type.
@@ -17,6 +15,8 @@ module BSON
       #   InvalidBinaryType.new(:error)
       #
       # @param [ Object ] type The invalid type.
+      #
+      # @api private
       def initialize(type)
         @type = type
       end

--- a/lib/bson/error/invalid_decimal128_argument.rb
+++ b/lib/bson/error/invalid_decimal128_argument.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+    # Raised when trying to create a Decimal128 from an object that is neither a String nor a BigDecimal.
+    #
+    # @api private
+    class InvalidDecimal128Argument < Error
+
+      # The custom error message for this error.
+      MESSAGE = 'A Decimal128 can only be created from a String or BigDecimal.'
+
+      # Get the custom error message for the exception.
+      #
+      # @example Get the message.
+      #   error.message
+      #
+      # @return [ String ] The error message.
+      def message
+        MESSAGE
+      end
+    end
+  end
+end
+

--- a/lib/bson/error/invalid_decimal128_argument.rb
+++ b/lib/bson/error/invalid_decimal128_argument.rb
@@ -2,9 +2,8 @@
 
 module BSON
   class Error
+
     # Raised when trying to create a Decimal128 from an object that is neither a String nor a BigDecimal.
-    #
-    # @api private
     class InvalidDecimal128Argument < Error
 
       # The custom error message for this error.

--- a/lib/bson/error/invalid_decimal128_range.rb
+++ b/lib/bson/error/invalid_decimal128_range.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when the exponent is outside the valid range.
+    class InvalidDecimal128Range < RuntimeError
+
+      # The custom error message for this error.
+      #
+      # @deprecated
+      MESSAGE = 'Value out of range for Decimal128 representation.'
+
+      # Get the custom error message for the exception.
+      #
+      # @example Get the message.
+      #   error.message
+      #
+      # @return [ String ] The error message.
+      def message
+        MESSAGE
+      end
+    end
+  end
+end
+

--- a/lib/bson/error/invalid_decimal128_string.rb
+++ b/lib/bson/error/invalid_decimal128_string.rb
@@ -5,8 +5,6 @@ module BSON
 
     # Raised when trying to create a Decimal128 from a string with
     #   an invalid format.
-    #
-    # @api private
     class InvalidDecimal128String < Error
 
       # The custom error message for this error.

--- a/lib/bson/error/invalid_decimal128_string.rb
+++ b/lib/bson/error/invalid_decimal128_string.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when trying to create a Decimal128 from a string with
+    #   an invalid format.
+    #
+    # @api private
+    class InvalidDecimal128String < Error
+
+      # The custom error message for this error.
+      MESSAGE = 'Invalid string format for creating a Decimal128 object.'
+
+      # Get the custom error message for the exception.
+      #
+      # @example Get the message.
+      #   error.message
+      #
+      # @return [ String ] The error message.
+      def message
+        MESSAGE
+      end
+    end
+  end
+end
+

--- a/lib/bson/error/invalid_key.rb
+++ b/lib/bson/error/invalid_key.rb
@@ -12,6 +12,8 @@ module BSON
       #   BSON::Object::InvalidKey.new(object)
       #
       # @param [ Object ] object The object that was meant for the key.
+      #
+      # @api private
       def initialize(object)
         super("#{object.class} instances are not allowed as keys in a BSON document.")
       end

--- a/lib/bson/error/invalid_key.rb
+++ b/lib/bson/error/invalid_key.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when trying to serialize an object into a key.
+    class InvalidKey < Error
+
+      # Instantiate the exception.
+      #
+      # @example Instantiate the exception.
+      #   BSON::Object::InvalidKey.new(object)
+      #
+      # @param [ Object ] object The object that was meant for the key.
+      def initialize(object)
+        super("#{object.class} instances are not allowed as keys in a BSON document.")
+      end
+    end
+  end
+end
+

--- a/lib/bson/error/invalid_object_id.rb
+++ b/lib/bson/error/invalid_object_id.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when trying to create an object id with invalid data.
+    class InvalidObjectId < Error; end
+  end
+end
+

--- a/lib/bson/error/invalid_regexp_pattern.rb
+++ b/lib/bson/error/invalid_regexp_pattern.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Exception raised when there is an invalid argument passed into the
+    # constructor of regexp object. This includes when the argument contains
+    # a null byte.
+    class InvalidRegexpPattern < Error
+    end
+  end
+end

--- a/lib/bson/error/unrepresentable_precision.rb
+++ b/lib/bson/error/unrepresentable_precision.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when the significand provided is outside the valid range.
+    class UnrepresentablePrecision < Error
+
+      # Get the custom error message for the exception.
+      #
+      # @return [ String ] The error message.
+      def message
+        'The value contains too much precision for Decimal128 representation'
+      end
+    end
+  end
+end
+

--- a/lib/bson/error/unserializable_class.rb
+++ b/lib/bson/error/unserializable_class.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Exception raised when serializing an Array or Hash to BSON and an
+    # array or hash element is of a class that does not define how to serialize
+    # itself to BSON.
+    class UnserializableClass < Error
+    end
+  end
+end

--- a/lib/bson/error/unsupported_binary_subtype.rb
+++ b/lib/bson/error/unsupported_binary_subtype.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Exception raised when decoding BSON and the data contains an
+    # unsupported binary subtype.
+    class UnsupportedBinarySubtype < Error
+    end
+  end
+end

--- a/lib/bson/error/unsupported_type.rb
+++ b/lib/bson/error/unsupported_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BSON
+  class Error
+
+    # Raised when trying to get a type from the registry that doesn't exist.
+    class UnsupportedType < Error; end
+  end
+end
+

--- a/lib/bson/object.rb
+++ b/lib/bson/object.rb
@@ -27,13 +27,13 @@ module BSON
     # @example Convert the object to a BSON key.
     #   object.to_bson_key
     #
-    # @raise [ InvalidKey ] Always raises an exception.
+    # @raise [ BSON::Error::InvalidKey ] Always raises an exception.
     #
     # @see http://bsonspec.org/#/specification
     #
     # @since 2.2.4
     def to_bson_key(validating_keys = Config.validating_keys?)
-      raise InvalidKey.new(self)
+      raise Error::InvalidKey.new(self)
     end
 
     # Converts the object to a normalized key in a BSON document.
@@ -82,24 +82,6 @@ module BSON
     # @return [ Object ] The extended json representation.
     def as_extended_json(**_options)
       self
-    end
-  end
-
-  # Raised when trying to serialize an object into a key.
-  #
-  # @since 2.2.4
-  class InvalidKey < RuntimeError
-
-    # Instantiate the exception.
-    #
-    # @example Instantiate the exception.
-    #   BSON::Object::InvalidKey.new(object)
-    #
-    # @param [ Object ] object The object that was meant for the key.
-    #
-    # @since 2.2.4
-    def initialize(object)
-      super("#{object.class} instances are not allowed as keys in a BSON document.")
     end
   end
 

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -198,11 +198,6 @@ module BSON
     end
     alias :to_str :to_s
 
-    # Raised when trying to create an object id with invalid data.
-    #
-    # @since 2.0.0
-    class Invalid < RuntimeError; end
-
     private
 
     def initialize_copy(other)
@@ -261,14 +256,14 @@ module BSON
       #
       # @param [ String ] string The string to create the id from.
       #
-      # @raise [ BSON::ObjectId::Invalid ] If the provided string is invalid.
+      # @raise [ BSON::Error::InvalidObjectId ] If the provided string is invalid.
       #
       # @return [ BSON::ObjectId ] The new object id.
       #
       # @since 2.0.0
       def from_string(string)
         unless legal?(string)
-          raise Invalid.new("'#{string}' is an invalid ObjectId.")
+          raise Error::InvalidObjectId.new("'#{string}' is an invalid ObjectId.")
         end
         from_data([ string ].pack("H*"))
       end
@@ -316,7 +311,7 @@ module BSON
       #
       # @param [ String, Array ] object The object to repair.
       #
-      # @raise [ Invalid ] If the array is not 12 elements.
+      # @raise [ BSON::Error::InvalidObjectId ] If the array is not 12 elements.
       #
       # @return [ String ] The result of the block.
       #
@@ -325,7 +320,7 @@ module BSON
         if object.size == 12
           block_given? ? yield(object) : object
         else
-          raise Invalid.new("#{object.inspect} is not a valid object id.")
+          raise Error::InvalidObjectId.new("#{object.inspect} is not a valid object id.")
         end
       end
     end

--- a/lib/bson/registry.rb
+++ b/lib/bson/registry.rb
@@ -64,11 +64,6 @@ module BSON
       define_type_reader(type)
     end
 
-    # Raised when trying to get a type from the registry that doesn't exist.
-    #
-    # @since 4.1.0
-    class UnsupportedType < RuntimeError; end
-
     private
 
     def define_type_reader(type)
@@ -81,7 +76,7 @@ module BSON
       message = "Detected unknown BSON type #{byte.inspect} "
       message += (field ? "for fieldname \"#{field}\". " : "in array. ")
       message +="Are you using the latest BSON version?"
-      raise UnsupportedType.new(message)
+      raise Error::UnsupportedType.new(message)
     end
   end
 end

--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -57,8 +57,8 @@ module BSON
     #
     # @raise [ EncodingError ] If the string is not UTF-8.
     #
-    # @raise [ IllegalKey ] If validating keys and it contains a '.' or starts
-    #   with '$'.
+    # @raise [ BSON::Error::IllegalKey ] If validating keys and it contains a
+    #   '.' or starts with '$'.
     #
     # @return [ String ] The encoded string.
     #
@@ -67,7 +67,7 @@ module BSON
     # @since 2.0.0
     def to_bson_key(validating_keys = Config.validating_keys?)
       if validating_keys
-        raise IllegalKey.new(self) if ILLEGAL_KEY =~ self
+        raise Error::IllegalKey.new(self) if ILLEGAL_KEY =~ self
       end
       self
     end
@@ -80,7 +80,7 @@ module BSON
     #
     # @note This is used for repairing legacy bson data.
     #
-    # @raise [ BSON::ObjectId::Invalid ] If the string is not 12 elements.
+    # @raise [ BSON::Error::InvalidObjectId ] If the string is not 12 elements.
     #
     # @return [ String ] The raw object id bytes.
     #
@@ -99,24 +99,6 @@ module BSON
     # @since 2.0.0
     def to_hex_string
       unpack("H*")[0]
-    end
-
-    # Raised when validating keys and a key is illegal in MongoDB
-    #
-    # @since 4.1.0
-    class IllegalKey < RuntimeError
-
-      # Instantiate the exception.
-      #
-      # @example Instantiate the exception.
-      #   BSON::Object::IllegalKey.new(string)
-      #
-      # @param [ String ] string The illegal string.
-      #
-      # @since 4.1.0
-      def initialize(string)
-        super("'#{string}' is an illegal key in MongoDB. Keys may not start with '$' or contain a '.'.")
-      end
     end
 
     module ClassMethods

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -73,7 +73,7 @@ module BSON
     # @since 2.0.0
     def to_bson_key(validating_keys = Config.validating_keys?)
       if validating_keys
-        raise BSON::String::IllegalKey.new(self) if BSON::String::ILLEGAL_KEY =~ self
+        raise BSON::Error::IllegalKey.new(self) if BSON::String::ILLEGAL_KEY =~ self
       end
       self
     end

--- a/spec/bson/array_spec.rb
+++ b/spec/bson/array_spec.rb
@@ -49,7 +49,7 @@ describe Array do
           it "raises an error" do
             expect {
               obj.to_bson
-            }.to raise_error(BSON::String::IllegalKey)
+            }.to raise_error(BSON::Error::IllegalKey)
           end
         end
 
@@ -58,7 +58,7 @@ describe Array do
           it "raises an error" do
             expect {
               obj.to_bson(BSON::ByteBuffer.new, true)
-            }.to raise_error(BSON::String::IllegalKey)
+            }.to raise_error(BSON::Error::IllegalKey)
           end
 
           context "when serializing different types" do
@@ -87,7 +87,7 @@ describe Array do
             it "raises an error" do
               expect {
                 obj.to_bson(BSON::ByteBuffer.new, true)
-              }.to raise_error(BSON::String::IllegalKey)
+              }.to raise_error(BSON::Error::IllegalKey)
             end
           end
         end
@@ -186,7 +186,7 @@ describe Array do
       it "raises an exception" do
         expect {
           [ 1 ].to_bson_object_id
-        }.to raise_error(BSON::ObjectId::Invalid)
+        }.to raise_error(BSON::Error::InvalidObjectId)
       end
     end
   end

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -211,7 +211,7 @@ describe BigDecimal do
       it "raises an error" do
         expect do
           BigDecimal(argument).to_bson
-        end.to raise_error(BSON::Decimal128::InvalidRange)
+        end.to raise_error(BSON::Error::InvalidDecimal128Range)
       end
     end
 
@@ -221,7 +221,7 @@ describe BigDecimal do
       it "raises an error" do
         expect do
           BigDecimal(argument).to_bson
-        end.to raise_error(BSON::Decimal128::UnrepresentablePrecision)
+        end.to raise_error(BSON::Error::UnrepresentablePrecision)
       end
     end
   end

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -87,7 +87,7 @@ describe BSON::Binary do
         expect {
           described_class.new("testing", :error)
         }.to raise_error { |error|
-          expect(error).to be_a(BSON::Binary::InvalidType)
+          expect(error).to be_a(BSON::Error::InvalidBinaryType)
           expect(error.message).to match /is not a valid binary type/
         }
       end

--- a/spec/bson/decimal128_spec.rb
+++ b/spec/bson/decimal128_spec.rb
@@ -28,10 +28,10 @@ describe BSON::Decimal128 do
 
     context 'when the argument is neither a BigDecimal or String' do
 
-      it 'raises an ArgumentError' do
+      it 'raises an InvalidDecimal128Argument error' do
         expect {
           described_class.new(:invalid)
-        }.to raise_exception(ArgumentError)
+        }.to raise_exception(BSON::Error::InvalidDecimal128Argument, /A Decimal128 can only be created from a String or BigDecimal./ )
       end
     end
 
@@ -314,7 +314,7 @@ describe BSON::Decimal128 do
       it 'raises InvalidRange' do
         lambda do
           described_class.new('1e10000')
-        end.should raise_error(BSON::Decimal128::InvalidRange, /Value out of range/)
+        end.should raise_error(BSON::Error::InvalidDecimal128Range, /Value out of range/)
       end
     end
 
@@ -322,7 +322,7 @@ describe BSON::Decimal128 do
       it 'raises UnrepresentablePrecision' do
         lambda do
           described_class.new('1.000000000000000000000000000000000000000000000000001')
-        end.should raise_error(BSON::Decimal128::UnrepresentablePrecision, /The value contains too much precision/)
+        end.should raise_error(BSON::Error::UnrepresentablePrecision, /The value contains too much precision/)
       end
     end
   end

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -73,7 +73,7 @@ describe Hash do
           it "raises an error" do
             expect {
               obj.to_bson
-            }.to raise_error(BSON::String::IllegalKey)
+            }.to raise_error(BSON::Error::IllegalKey)
           end
 
           context "when the hash contains an array of documents containing invalid keys" do
@@ -85,7 +85,7 @@ describe Hash do
             it "raises an error" do
               expect {
                 obj.to_bson
-              }.to raise_error(BSON::String::IllegalKey)
+              }.to raise_error(BSON::Error::IllegalKey)
             end
           end
         end
@@ -95,7 +95,7 @@ describe Hash do
           it "raises an error" do
             expect {
               obj.to_bson(BSON::ByteBuffer.new, true)
-            }.to raise_error(BSON::String::IllegalKey)
+            }.to raise_error(BSON::Error::IllegalKey)
           end
 
           context "when the hash contains an array of documents containing invalid keys" do
@@ -107,7 +107,7 @@ describe Hash do
             it "raises an error" do
               expect {
                 obj.to_bson(BSON::ByteBuffer.new, true)
-              }.to raise_error(BSON::String::IllegalKey)
+              }.to raise_error(BSON::Error::IllegalKey)
             end
           end
         end

--- a/spec/bson/object_id_spec.rb
+++ b/spec/bson/object_id_spec.rb
@@ -322,7 +322,7 @@ describe BSON::ObjectId do
       it "raises an error" do
         expect {
           described_class.from_string("asadsf")
-        }.to raise_error(BSON::ObjectId::Invalid)
+        }.to raise_error(BSON::Error::InvalidObjectId)
       end
     end
   end
@@ -603,7 +603,7 @@ describe BSON::ObjectId do
     it "raises an exception on serialization" do
       expect {
         hash.to_bson
-      }.to raise_error(BSON::InvalidKey)
+      }.to raise_error(BSON::Error::InvalidKey)
     end
   end
 end

--- a/spec/bson/object_spec.rb
+++ b/spec/bson/object_spec.rb
@@ -25,7 +25,7 @@ describe BSON::Object do
     it "raises an exception" do
       expect {
         object.to_bson_key
-      }.to raise_error(BSON::InvalidKey)
+      }.to raise_error(BSON::Error::InvalidKey)
     end
   end
 end

--- a/spec/bson/open_struct_spec.rb
+++ b/spec/bson/open_struct_spec.rb
@@ -57,7 +57,7 @@ describe OpenStruct do
           it "raises an error" do
             expect {
               obj.to_bson
-            }.to raise_error(BSON::String::IllegalKey)
+            }.to raise_error(BSON::Error::IllegalKey)
           end
 
           context "when the struct contains an array of documents containing invalid keys" do
@@ -69,7 +69,7 @@ describe OpenStruct do
             it "raises an error" do
               expect {
                 obj.to_bson
-              }.to raise_error(BSON::String::IllegalKey)
+              }.to raise_error(BSON::Error::IllegalKey)
             end
           end
         end
@@ -79,7 +79,7 @@ describe OpenStruct do
           it "raises an error" do
             expect {
               obj.to_bson(BSON::ByteBuffer.new, true)
-            }.to raise_error(BSON::String::IllegalKey)
+            }.to raise_error(BSON::Error::IllegalKey)
           end
 
           context "when the struct contains an array of documents containing invalid keys" do
@@ -91,7 +91,7 @@ describe OpenStruct do
             it "raises an error" do
               expect {
                 obj.to_bson(BSON::ByteBuffer.new, true)
-              }.to raise_error(BSON::String::IllegalKey)
+              }.to raise_error(BSON::Error::IllegalKey)
             end
           end
         end

--- a/spec/bson/registry_spec.rb
+++ b/spec/bson/registry_spec.rb
@@ -38,7 +38,7 @@ describe BSON::Registry do
       it "raises an error" do
         expect {
           described_class.get(25.chr, "field")
-        }.to raise_error(BSON::Registry::UnsupportedType)
+        }.to raise_error(BSON::Error::UnsupportedType)
       end
     end
   end

--- a/spec/bson/string_spec.rb
+++ b/spec/bson/string_spec.rb
@@ -51,7 +51,7 @@ describe String do
       it "raises an exception" do
         expect {
           "test".to_bson_object_id
-        }.to raise_error(BSON::ObjectId::Invalid)
+        }.to raise_error(BSON::Error::InvalidObjectId)
       end
     end
   end

--- a/spec/bson/symbol_spec.rb
+++ b/spec/bson/symbol_spec.rb
@@ -115,7 +115,7 @@ describe Symbol do
       it "raises an exception" do
         expect {
           symbol.to_bson_key(true)
-        }.to raise_error(BSON::String::IllegalKey)
+        }.to raise_error(BSON::Error::IllegalKey)
       end
     end
 

--- a/spec/spec_tests/common_driver_spec.rb
+++ b/spec/spec_tests/common_driver_spec.rb
@@ -67,9 +67,9 @@ describe 'Driver common bson tests' do
 
           let(:valid_errors) do
             [
-              BSON::Decimal128::InvalidString,
-              BSON::Decimal128::InvalidRange,
-              BSON::Decimal128::UnrepresentablePrecision,
+              BSON::Error::InvalidDecimal128String,
+              BSON::Error::InvalidDecimal128Range,
+              BSON::Error::UnrepresentablePrecision,
             ]
           end
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -155,7 +155,7 @@ shared_examples_for "a validated BSON key" do
       it "raises an exception" do
         expect {
           validated
-        }.to raise_error(BSON::String::IllegalKey)
+        }.to raise_error(BSON::Error::IllegalKey)
       end
     end
 
@@ -168,7 +168,7 @@ shared_examples_for "a validated BSON key" do
       it "raises an exception" do
         expect {
           validated
-        }.to raise_error(BSON::String::IllegalKey)
+        }.to raise_error(BSON::Error::IllegalKey)
       end
     end
   end


### PR DESCRIPTION
This is one part of a multiple part PR. The next PR will create `BSON::Error`s for the various Ruby errors in bson.

The following BSON errors were renamed:
- `BSON::String::IllegalKey` -> `BSON::Error::IllegalKey`
- `BSON::Binary::InvalidType` -> `BSON::Error::InvalidBinaryType`
- `BSON::Decimal128::InvalidArgument` -> `BSON::Error::InvalidDecimal128Argument`
- `BSON::Decimal128::InvalidRange` -> `BSON::Error::InvalidDecimal128Range`
- `BSON::Decimal128::InvalidString` -> `BSON::Error::InvalidDecimal128String`
- `BSON::Object::InvalidKey` -> `BSON::Error::InvalidKey`
- `BSON::ObjectId::Invalid` -> `BSON::Error::InvalidObjectId`
- `BSON::Decimal128::UnrepresentablePrecision` -> `BSON::Error::UnrepresentablePrecision`
- `BSON::Registry::UnsupportedType` -> `BSON::Error::UnsupportedType`

The following errors remained the same:
- `BSON::Error::BsonDecodeError`
- `BSON::Error::ExtJsonParseError`
- `BSON::Error::InvalidRegexpPattern`
- `BSON::Error::UnserializableClass`
- `BSON::Error::UnsupportedBinarySubtype`