### PR TITLE
RUBY-3140 - Change Decimal128#to_big_decimal to #to_d following Ruby conventions

### DIFF
--- a/lib/bson/big_decimal.rb
+++ b/lib/bson/big_decimal.rb
@@ -61,7 +61,7 @@ module BSON
         if options[:mode] == :bson
           dec128
         else
-          dec128.to_big_decimal
+          dec128.to_d
         end
       end
     end

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -100,9 +100,9 @@ module BSON
     alias :eql? :==
 
     def <=>(other)
-      to_big_decimal <=> case other
+      to_d <=> case other
         when Decimal128
-          other.to_big_decimal
+          other.to_d
         else
           other
         end
@@ -195,7 +195,7 @@ module BSON
     # @example
     #  decimal128 = BSON::Decimal128.new("0.200")
     #    => BSON::Decimal128('0.200')
-    #  big_decimal = decimal128.to_big_decimal
+    #  big_decimal = decimal128.to_d
     #    => #<BigDecimal:7fc619c95388,'0.2E0',9(18)>
     #  big_decimal.to_s
     #    => "0.2E0"
@@ -204,11 +204,10 @@ module BSON
     # and -sNaN while Ruby's BigDecimal cannot.
     #
     # @return [ BigDecimal ] The decimal as a BigDecimal.
-    #
-    # @since 4.2.0
-    def to_big_decimal
+    def to_d
       @big_decimal ||= BigDecimal(to_s)
     end
+    alias :to_big_decimal :to_d
 
     private
 

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -35,7 +35,7 @@ describe BigDecimal do
         if deserialized_decimal128.to_s == "NaN"
           expect(deserialized_big_decimal.nan?).to be true
         else
-          expect(deserialized_big_decimal).to eq(deserialized_decimal128.to_big_decimal)
+          expect(deserialized_big_decimal).to eq(deserialized_decimal128.to_d)
         end
       end
     end

--- a/spec/bson/decimal128_spec.rb
+++ b/spec/bson/decimal128_spec.rb
@@ -1388,7 +1388,7 @@ describe BSON::Decimal128 do
     end
   end
 
-  describe "#to_big_decimal" do
+  describe "#to_d" do
 
     shared_examples_for 'a decimal128 convertible to a Ruby BigDecimal' do
 
@@ -1397,6 +1397,10 @@ describe BSON::Decimal128 do
       end
 
       it 'properly converts the Decimal128 to a BigDecimal' do
+        expect(decimal128.to_d).to eq(expected_big_decimal)
+      end
+
+      it 'permits the alias #to_big_decimal' do
         expect(decimal128.to_big_decimal).to eq(expected_big_decimal)
       end
     end


### PR DESCRIPTION
Keep #to_big_decimal as an alias.