### PR TITLE
Set up rubocop with all files opted out (to be opted in piecemeal)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,55 @@
+require:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 2.5
+  NewCops: enable
+  Exclude:
+    - 'spec/shared/**/*'
+
+Gemspec:
+  Enabled: true
+
+Layout:
+  Enabled: true
+
+Lint:
+  Enabled: true
+
+Metrics:
+  Enabled: true
+
+Naming:
+  Enabled: true
+
+Performance:
+  Enabled: true
+
+Rake:
+  Enabled: true
+
+RSpec:
+  Enabled: true
+
+Security:
+  Exclude:
+    - 'spec/**/*'
+
+Style:
+  Enabled: true
+
+# --------------------------------------
+# Cops below this line set intentionally
+# --------------------------------------
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
 source 'https://rubygems.org'
 
 gemspec
@@ -19,6 +22,11 @@ group :development, :test do
   gem 'byebug', platforms: :mri
   # https://github.com/jruby/jruby/wiki/UsingTheJRubyDebugger
   gem 'ruby-debug', platforms: :jruby
+
+  gem 'rubocop', '~> 1.45.1'
+  gem 'rubocop-performance', '~> 1.16.0'
+  gem 'rubocop-rake', '~> 0.6.0'
+  gem 'rubocop-rspec', '~> 2.18.1'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,14 @@ group :development, :test do
   # https://github.com/jruby/jruby/wiki/UsingTheJRubyDebugger
   gem 'ruby-debug', platforms: :jruby
 
-  gem 'rubocop', '~> 1.45.1'
-  gem 'rubocop-performance', '~> 1.16.0'
-  gem 'rubocop-rake', '~> 0.6.0'
-  gem 'rubocop-rspec', '~> 2.18.1'
+  # Ruby 2.5 wants an older version of rubocop. Rather than try to
+  # please everybody, we'll just not install rubocop for Ruby 2.5.
+  if RUBY_VERSION > "2.5.99"
+    gem 'rubocop', '~> 1.45.1'
+    gem 'rubocop-performance', '~> 1.16.0'
+    gem 'rubocop-rake', '~> 0.6.0'
+    gem 'rubocop-rspec', '~> 2.18.1'
+  end
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
 # Copyright (C) 2009-2013 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bson.gemspec
+++ b/bson.gemspec
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bson/version'

--- a/ext/bson/extconf.rb
+++ b/ext/bson/extconf.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require "mkmf"
 $CFLAGS << " -Wall -g -std=c99"
 create_makefile("bson_native")

--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/active_support.rb
+++ b/lib/bson/active_support.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2018-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/array.rb
+++ b/lib/bson/array.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/big_decimal.rb
+++ b/lib/bson/big_decimal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2021 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/boolean.rb
+++ b/lib/bson/boolean.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/code.rb
+++ b/lib/bson/code.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/code_with_scope.rb
+++ b/lib/bson/code_with_scope.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/config.rb
+++ b/lib/bson/config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/date_time.rb
+++ b/lib/bson/date_time.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/db_pointer.rb
+++ b/lib/bson/db_pointer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/dbref.rb
+++ b/lib/bson/dbref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# encoding: utf-8
+# rubocop:todo all
 
 # Copyright (C) 2015-2021 MongoDB Inc.
 #

--- a/lib/bson/decimal128.rb
+++ b/lib/bson/decimal128.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/environment.rb
+++ b/lib/bson/environment.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/error.rb
+++ b/lib/bson/error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 module BSON
   # Base exception class for all BSON-related errors.
   class Error < StandardError

--- a/lib/bson/error/bson_decode_error.rb
+++ b/lib/bson/error/bson_decode_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/ext_json_parse_error.rb
+++ b/lib/bson/error/ext_json_parse_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/illegal_key.rb
+++ b/lib/bson/error/illegal_key.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_binary_type.rb
+++ b/lib/bson/error/invalid_binary_type.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_dbref_argument.rb
+++ b/lib/bson/error/invalid_dbref_argument.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_decimal128_argument.rb
+++ b/lib/bson/error/invalid_decimal128_argument.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_decimal128_range.rb
+++ b/lib/bson/error/invalid_decimal128_range.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_decimal128_string.rb
+++ b/lib/bson/error/invalid_decimal128_string.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_key.rb
+++ b/lib/bson/error/invalid_key.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_object_id.rb
+++ b/lib/bson/error/invalid_object_id.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/invalid_regexp_pattern.rb
+++ b/lib/bson/error/invalid_regexp_pattern.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/unrepresentable_precision.rb
+++ b/lib/bson/error/unrepresentable_precision.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/unserializable_class.rb
+++ b/lib/bson/error/unserializable_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/unsupported_binary_subtype.rb
+++ b/lib/bson/error/unsupported_binary_subtype.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/error/unsupported_type.rb
+++ b/lib/bson/error/unsupported_type.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 module BSON
   class Error

--- a/lib/bson/ext_json.rb
+++ b/lib/bson/ext_json.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2019-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/false_class.rb
+++ b/lib/bson/false_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/float.rb
+++ b/lib/bson/float.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/int32.rb
+++ b/lib/bson/int32.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/int64.rb
+++ b/lib/bson/int64.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/integer.rb
+++ b/lib/bson/integer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/json.rb
+++ b/lib/bson/json.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/max_key.rb
+++ b/lib/bson/max_key.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/min_key.rb
+++ b/lib/bson/min_key.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/nil_class.rb
+++ b/lib/bson/nil_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/object.rb
+++ b/lib/bson/object.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/open_struct.rb
+++ b/lib/bson/open_struct.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/registry.rb
+++ b/lib/bson/registry.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/specialized.rb
+++ b/lib/bson/specialized.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/string.rb
+++ b/lib/bson/string.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 # Copyright (C) 2009-2020 MongoDB Inc.

--- a/lib/bson/symbol.rb
+++ b/lib/bson/symbol.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/time.rb
+++ b/lib/bson/time.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/time_with_zone.rb
+++ b/lib/bson/time_with_zone.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2018-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/timestamp.rb
+++ b/lib/bson/timestamp.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/true_class.rb
+++ b/lib/bson/true_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/undefined.rb
+++ b/lib/bson/undefined.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/perf/Rakefile
+++ b/perf/Rakefile
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2013 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/perf/bench.rb
+++ b/perf/bench.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/perf/bench_test.rb
+++ b/perf/bench_test.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/array_spec.rb
+++ b/spec/bson/array_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2016-2021 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/binary_uuid_spec.rb
+++ b/spec/bson/binary_uuid_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2019-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/boolean_spec.rb
+++ b/spec/bson/boolean_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/byte_buffer_read_spec.rb
+++ b/spec/bson/byte_buffer_read_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 
 describe BSON::ByteBuffer do

--- a/spec/bson/byte_buffer_spec.rb
+++ b/spec/bson/byte_buffer_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 
 describe BSON::ByteBuffer do

--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 
 describe BSON::ByteBuffer do

--- a/spec/bson/code_spec.rb
+++ b/spec/bson/code_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/code_with_scope_spec.rb
+++ b/spec/bson/code_with_scope_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/config_spec.rb
+++ b/spec/bson/config_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require "spec_helper"
 
 describe BSON::Config do

--- a/spec/bson/date_spec.rb
+++ b/spec/bson/date_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/date_time_spec.rb
+++ b/spec/bson/date_time_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/dbref_legacy_spec.rb
+++ b/spec/bson/dbref_legacy_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# encoding: utf-8
+# rubocop:todo all
 
 require 'spec_helper'
 require 'json'

--- a/spec/bson/dbref_spec.rb
+++ b/spec/bson/dbref_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# encoding: utf-8
+# rubocop:todo all
 
 require 'spec_helper'
 require 'json'

--- a/spec/bson/decimal128_spec.rb
+++ b/spec/bson/decimal128_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/document_as_spec.rb
+++ b/spec/bson/document_as_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2021 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/document_spec.rb
+++ b/spec/bson/document_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# rubocop:todo all
 
 # Copyright (C) 2009-2020 MongoDB Inc.
 #

--- a/spec/bson/ext_json_parse_spec.rb
+++ b/spec/bson/ext_json_parse_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/false_class_spec.rb
+++ b/spec/bson/false_class_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/float_spec.rb
+++ b/spec/bson/float_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/hash_as_spec.rb
+++ b/spec/bson/hash_as_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2021 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/hash_spec.rb
+++ b/spec/bson/hash_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/int32_spec.rb
+++ b/spec/bson/int32_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/int64_spec.rb
+++ b/spec/bson/int64_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/integer_spec.rb
+++ b/spec/bson/integer_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/json_spec.rb
+++ b/spec/bson/json_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/max_key_spec.rb
+++ b/spec/bson/max_key_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/min_key_spec.rb
+++ b/spec/bson/min_key_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/nil_class_spec.rb
+++ b/spec/bson/nil_class_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/object_id_spec.rb
+++ b/spec/bson/object_id_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/object_spec.rb
+++ b/spec/bson/object_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/open_struct_spec.rb
+++ b/spec/bson/open_struct_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/raw_spec.rb
+++ b/spec/bson/raw_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 
 describe Regexp::Raw do

--- a/spec/bson/regexp_spec.rb
+++ b/spec/bson/regexp_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/registry_spec.rb
+++ b/spec/bson/registry_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/string_spec.rb
+++ b/spec/bson/string_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# rubocop:todo all
 
 # Copyright (C) 2009-2020 MongoDB Inc.
 #

--- a/spec/bson/symbol_raw_spec.rb
+++ b/spec/bson/symbol_raw_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/symbol_spec.rb
+++ b/spec/bson/symbol_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/time_spec.rb
+++ b/spec/bson/time_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/time_with_zone_spec.rb
+++ b/spec/bson/time_with_zone_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2018-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/timestamp_spec.rb
+++ b/spec/bson/timestamp_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/true_class_spec.rb
+++ b/spec/bson/true_class_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson/undefined_spec.rb
+++ b/spec/bson/undefined_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/bson_spec.rb
+++ b/spec/bson_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/runners/common_driver.rb
+++ b/spec/runners/common_driver.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/runners/corpus.rb
+++ b/spec/runners/corpus.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/runners/corpus_legacy.rb
+++ b/spec/runners/corpus_legacy.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2016-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/spec_tests/common_driver_spec.rb
+++ b/spec/spec_tests/common_driver_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 require 'runners/common_driver'
 

--- a/spec/spec_tests/corpus_legacy_spec.rb
+++ b/spec/spec_tests/corpus_legacy_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 require 'runners/corpus_legacy'
 

--- a/spec/spec_tests/corpus_spec.rb
+++ b/spec/spec_tests/corpus_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'spec_helper'
 require 'runners/corpus'
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 require 'singleton'
 
 class SpecConfig

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -1,3 +1,4 @@
+# rubocop:todo all
 module Utils
   # JRuby chokes when strings like "\xfe\x00\xff", which are not valid UTF-8,
   # appear in the source. Use this method to build such strings.


### PR DESCRIPTION
See https://github.com/mongodb/mongoid/pull/5608 for the justification for this PR.

TL;DR: This PR sets up Rubocop with all cops enabled, and opts all files out of the linter. As files are touched moving forward, they may be opted into linting by removing the `# rubocop:todo all` line at the top.