### PR TITLE
RUBY-1168 Correct BSON corpus Decimal128 test failures

### DIFF
--- a/spec/bson/dbref_legacy_spec.rb
+++ b/spec/bson/dbref_legacy_spec.rb
@@ -8,7 +8,24 @@ require 'json'
 # class, and are intended to verify that the current DBRef implementation is
 # compatible with the legacy driver DBRef interface.
 
-describe BSON::DBRef do
+# For testing a class that emits warnings, without spamming the terminal
+# with them.
+def silenced_version_of(klass)
+  Class.new(klass) do
+    class <<self
+      def name
+        "#{superclass.name} (silenced)"
+      end
+
+      alias to_s name
+    end
+
+    def warn(*_args)
+    end
+  end
+end
+
+describe silenced_version_of BSON::DBRef do
 
   let(:object_id) do
     BSON::ObjectId.new

--- a/spec/bson/decimal128_spec.rb
+++ b/spec/bson/decimal128_spec.rb
@@ -1283,7 +1283,6 @@ describe BSON::Decimal128 do
         end
 
         it "returns nil to be consistent with ActiveSupport" do
-          puts object.as_json
           expect(object.as_json).to eq(nil)
         end
       end

--- a/spec/runners/corpus.rb
+++ b/spec/runners/corpus.rb
@@ -58,6 +58,10 @@ module BSON
         @spec['test_key']
       end
 
+      def bson_type
+        @bson_type ||= @spec['bson_type'].to_i(16).chr
+      end
+
       def valid_tests
         @valid_tests ||=
           @spec['valid']&.map do |test_spec|
@@ -180,6 +184,7 @@ module BSON
         @string = test_params['string']
       end
 
+      attr_reader :spec
       attr_reader :description, :string
     end
   end

--- a/spec/spec_tests/corpus_spec.rb
+++ b/spec/spec_tests/corpus_spec.rb
@@ -106,8 +106,17 @@ describe 'BSON Corpus spec tests' do
 
         context("parse error: #{test.description}") do
 
-          let(:parsed_extjson) do
-            BSON::ExtJSON.parse(test.string, mode: :bson)
+          # As per:
+          #   https://github.com/mongodb/specifications/blob/e7ee829329400786e01279b4f37d4e440d1e9cfa/source/bson-corpus/bson-corpus.rst#decimal128-type-0x13
+          #
+          # Values under test must be parsed in a type-specific manner.
+          let(:parsed_value) do
+            case spec.bson_type
+            when BSON::Decimal128::BSON_TYPE
+              BSON::Decimal128.new(test.string)
+            else
+              BSON::ExtJSON.parse(test.string, mode: :bson)
+            end
           end
 
           # Until bson-ruby gets an exception hierarchy, we can only rescue
@@ -115,7 +124,7 @@ describe 'BSON Corpus spec tests' do
           # https://jira.mongodb.org/browse/RUBY-1806
           it 'raises an exception' do
             expect do
-              parsed_extjson
+              parsed_value
             end.to raise_error(Exception)
           end
         end

--- a/spec/spec_tests/data/corpus/decimal128-4.json
+++ b/spec/spec_tests/data/corpus/decimal128-4.json
@@ -112,6 +112,54 @@
        {
           "description": "[basx563] Near-specials (Conversion_syntax)",
           "string": "NaNs"
+       },
+       {
+          "description": "[dqbas939] overflow results at different rounding modes (Overflow & Inexact & Rounded)",
+          "string": "-7e10000"
+       },
+       {
+          "description": "[dqbsr534] negatives (Rounded & Inexact)",
+          "string": "-1.11111111111111111111111111111234650"
+       },
+       {
+          "description": "[dqbsr535] negatives (Rounded & Inexact)",
+          "string": "-1.11111111111111111111111111111234551"
+       },
+       {
+          "description": "[dqbsr533] negatives (Rounded & Inexact)",
+          "string": "-1.11111111111111111111111111111234550"
+       },
+       {
+          "description": "[dqbsr532] negatives (Rounded & Inexact)",
+          "string": "-1.11111111111111111111111111111234549"
+       },
+       {
+          "description": "[dqbsr432] check rounding modes heeded (Rounded & Inexact)",
+          "string": "1.11111111111111111111111111111234549"
+       },
+       {
+          "description": "[dqbsr433] check rounding modes heeded (Rounded & Inexact)",
+          "string": "1.11111111111111111111111111111234550"
+       },
+       {
+          "description": "[dqbsr435] check rounding modes heeded (Rounded & Inexact)",
+          "string": "1.11111111111111111111111111111234551"
+       },
+       {
+          "description": "[dqbsr434] check rounding modes heeded (Rounded & Inexact)",
+          "string": "1.11111111111111111111111111111234650"
+       },
+       {
+          "description": "[dqbas938] overflow results at different rounding modes (Overflow & Inexact & Rounded)",
+          "string": "7e10000"
+       },
+       {
+          "description": "Inexact rounding#1",
+          "string": "100000000000000000000000000000000000000000000000000000000001"
+       },
+       {
+          "description": "Inexact rounding#2",
+          "string": "1E-6177"
        }
     ]
 }

--- a/spec/spec_tests/data/corpus/decimal128-6.json
+++ b/spec/spec_tests/data/corpus/decimal128-6.json
@@ -76,6 +76,18 @@
             "string": ""
         },
         {
+            "description": "leading white space positive number",
+            "string": " 1"
+        },
+        {
+            "description": "leading white space negative number",
+            "string": " -1"
+        },
+        {
+            "description": "trailing white space",
+            "string": "1 "
+        },
+        {
             "description": "Invalid",
             "string": "E"
         },

--- a/spec/spec_tests/data/corpus/decimal128-7.json
+++ b/spec/spec_tests/data/corpus/decimal128-7.json
@@ -268,6 +268,10 @@
           "string": "9Inf"
        },
        {
+          "description": "[basx512] The 'baddies' tests from DiagBigDecimal, plus some new ones (Conversion_syntax)",
+          "string": "12 "
+       },
+       {
           "description": "[basx517] The 'baddies' tests from DiagBigDecimal, plus some new ones (Conversion_syntax)",
           "string": "12-"
        },


### PR DESCRIPTION
There were Decimal128 tests omitted because they were failing. The solution was to use type-specific parsing (e.g. `Decimal128::Builder`, versus `BSON::ExtJSON`) as required by the spec. No changes to code were necessary, only changes to the spec runner.