### PR TITLE
RUBY-3305 enable detections of arc4random from libbsd

### DIFF
--- a/ext/bson/extconf.rb
+++ b/ext/bson/extconf.rb
@@ -4,6 +4,7 @@
 require 'mkmf'
 
 $CFLAGS << ' -Wall -g -std=c99'
+have_library 'bsd'
 have_func 'arc4random'
 
 create_makefile('bson_native')


### PR DESCRIPTION
A little change to enable `arc4random` on Linux when `libbsd` header exists.  
This change is not necessary if you can integrate `internal/random.h` from MRI as discussed in #311; that API is better and more robust.

With this change, to enable secure-randomized counter initialization for ObjectID, just make sure to install `libbsd-dev` on distros derived from Debian.