### PR TITLE
final tweaks for BSON 5 release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -6,11 +6,25 @@ NAME=bson
 RELEASE_NAME=bson-ruby-release
 VERSION_REQUIRE=bson/version
 VERSION_CONSTANT_NAME=BSON::VERSION
+CMD=echo
 
 if ! test -f gem-private_key.pem; then
   echo "gem-private_key.pem missing - cannot release" 1>&2
   exit 1
 fi
+
+if test -z "$PRODUCTION_RELEASE"; then
+  echo "PRODUCTION_RELEASE is not set. The script will run in 'dry run'"
+  echo "mode. The gems will be built, but not actually published. To"
+  echo "publish the gems, set the PRODUCTION_RELEASE env variable to 1 and"
+  echo "re-run this script."
+else
+  echo "PRODUCTION_RELEASE is set. Gems will be built and published."
+  CMD=''
+fi
+
+echo
+read -p "-- Press RETURN to continue, or CTRL-C to abort --"
 
 VERSION=`ruby -Ilib -r$VERSION_REQUIRE -e "puts $VERSION_CONSTANT_NAME"`
 
@@ -41,8 +55,13 @@ echo Built: $NAME-$VERSION.gem
 echo Built: $NAME-$VERSION-java.gem
 echo
 
-git tag -a v$VERSION -m "Tagging release: $VERSION"
-git push origin v$VERSION
+if test -z "$PRODUCTION_RELEASE"; then
+  echo "*** SHOWING COMMANDS IN 'DRY RUN' MODE ***"
+  echo
+fi
 
-gem push $NAME-$VERSION.gem
-gem push $NAME-$VERSION-java.gem
+$CMD git tag -a v$VERSION -m "Tagging release: $VERSION"
+$CMD git push origin v$VERSION
+
+$CMD gem push $NAME-$VERSION.gem
+$CMD gem push $NAME-$VERSION-java.gem

--- a/release/jruby/Dockerfile
+++ b/release/jruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM debian:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # https://github.com/hazelcast/hazelcast/issues/14214
 
 RUN apt-get update && \
-  apt-get -y install openjdk-8-jdk ruby git curl make g++
+  apt-get -y install openjdk-17-jdk ruby git curl make g++
 
 WORKDIR /rubies
 COPY release/jruby/install.sh /rubies/

--- a/release/jruby/install.sh
+++ b/release/jruby/install.sh
@@ -8,4 +8,8 @@ cd /rubies
 git clone https://github.com/rbenv/ruby-build.git
 PREFIX=/usr ./ruby-build/install.sh
 
-ruby-build -v jruby-9.3.13.0 /rubies/jruby
+# JRuby 9.3.9.0 is the most recent version that uses
+# JOpenSSL 0.12.2. More recent versions use JOpenSSL 0.14.2,
+# which appears to be unable to build signed gems.
+# See: https://github.com/jruby/jruby-openssl/issues/292
+ruby-build -v jruby-9.3.9.0 /rubies/jruby

--- a/release/mri/Dockerfile
+++ b/release/mri/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Final tweaks for BSON 5 release -- had to adjust JDK versions and minimum ruby versions and the JRuby version used to bundle the java gem. Also tweaked the release script to add a "dry run" mode.