### PR TITLE
SECBUG-240 Fix out-of-bounds reads (backport to 4.15-stable)

### DIFF
--- a/ext/bson/read.c
+++ b/ext/bson/read.c
@@ -29,6 +29,7 @@ static VALUE pvt_get_symbol(byte_buffer_t *b, VALUE rb_buffer, int argc, VALUE *
 static VALUE pvt_get_boolean(byte_buffer_t *b);
 static VALUE pvt_read_field(byte_buffer_t *b, VALUE rb_buffer, uint8_t type, int argc, VALUE *argv);
 static void pvt_skip_cstring(byte_buffer_t *b);
+static size_t pvt_strnlen(const byte_buffer_t *b);
 
 void pvt_raise_decode_error(volatile VALUE msg) {
   VALUE klass = pvt_const_get_3("BSON", "Error", "BSONDecodeError");
@@ -128,7 +129,7 @@ VALUE rb_bson_byte_buffer_get_bytes(VALUE self, VALUE i)
 }
 
 VALUE pvt_get_boolean(byte_buffer_t *b){
-  VALUE result;
+  VALUE result = Qnil;
   char byte_value;
   ENSURE_BSON_READ(b, 1);
   byte_value = *READ_PTR(b);
@@ -221,7 +222,7 @@ VALUE rb_bson_byte_buffer_get_cstring(VALUE self)
   int length;
 
   TypedData_Get_Struct(self, byte_buffer_t, &rb_byte_buffer_data_type, b);
-  length = (int)strlen(READ_PTR(b));
+  length = (int)pvt_strnlen(b);
   ENSURE_BSON_READ(b, length);
   string = rb_enc_str_new(READ_PTR(b), length, rb_utf8_encoding());
   b->read_position += length + 1;
@@ -234,7 +235,7 @@ VALUE rb_bson_byte_buffer_get_cstring(VALUE self)
 void pvt_skip_cstring(byte_buffer_t *b)
 {
   int length;
-  length = (int)strlen(READ_PTR(b));
+  length = (int)pvt_strnlen(b);
   ENSURE_BSON_READ(b, length);
   b->read_position += length + 1;
 }
@@ -437,4 +438,18 @@ VALUE rb_bson_byte_buffer_get_array(int argc, VALUE *argv, VALUE self){
   }
 
   return array;
+}
+
+/**
+ * Returns the length of the given string `str`. If no null-terminating byte
+ * is present when `len` bytes have been scanned, then `len` is
+ * returned.
+ */
+size_t pvt_strnlen(const byte_buffer_t *b) {
+  const char *ptr = memchr(READ_PTR(b), '\0', READ_SIZE(b));
+
+  if (!ptr)
+    rb_raise(rb_eRangeError, "string is too long (possibly not null-terminated)");
+
+  return (size_t)(ptr - READ_PTR(b));
 }

--- a/ext/bson/write.c
+++ b/ext/bson/write.c
@@ -642,6 +642,10 @@ void pvt_put_array_index(byte_buffer_t *b, int32_t index)
     c_str = buffer;
     snprintf(buffer, sizeof(buffer), "%d", index);
   }
+  // strlen is a potential vector for out-of-bounds errors, but
+  // the only way for that to happen here, specifically, is if `index`
+  // is greater than 10e16 - 1, which is far beyond the domain of an
+  // int32.
   length = strlen(c_str) + 1;
   ENSURE_BSON_WRITE(b, length);
   memcpy(WRITE_PTR(b), c_str, length);

--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 module BSON
-  VERSION = "4.15.0"
+  VERSION = "4.15.1"
 end


### PR DESCRIPTION
Using strlen may result in reading beyond the end of the buffer (if the buffer is not null-terminated). For this reason, we should avoid using strlen and prefer a more explicit approach that also takes into account the size of the buffer.

(Backport of #325)