### PR TITLE
Fix release process so it pushes gems to RubyGems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,6 @@ jobs:
     environment: release
     runs-on: ubuntu-latest
     steps:
-      - name: testing value comparisons
-        if: inputs.dry_run == true
-        shell: bash
-        run: |
-          echo This should be printed
-          exit 1
-
       - name: Check out the repository
         uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,13 @@ jobs:
     environment: release
     runs-on: ubuntu-latest
     steps:
+      - name: testing value comparisons
+        if: inputs.dry_run == true
+        shell: bash
+        run: |
+          echo This should be printed
+          exit 1
+
       - name: Check out the repository
         uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
         with:
@@ -165,6 +172,6 @@ jobs:
 
       - name: Publish the gems
         uses: rubygems/release-gem@v1
-        if: inputs.dry_run == 'false'
+        if: inputs.dry_run == false
         with:
           await-release: false


### PR DESCRIPTION
The automated release process is currently skipping the part where it actually pushes the gems it produces to RubyGems. This PR fixes that, by correcting the value that the `dry_run` input is compared against. (When passed into another action, this input is apparently converted into a string, and requires quotes. When used directly, it remains a boolean, and must not be quoted.)