### PR TITLE
Use correct regexp lowercase \z terminator

### DIFF
--- a/lib/bson/decimal128/builder.rb
+++ b/lib/bson/decimal128/builder.rb
@@ -156,7 +156,7 @@ module BSON
         # @return [ Regex ] The regex for a valid decimal128 string.
         #
         # @since 4.2.0
-        VALID_DECIMAL128_STRING_REGEX = /\A[\-\+]?(\d+(\.\d*)?|\.\d+)(E[\-\+]?\d+)?\Z/i
+        VALID_DECIMAL128_STRING_REGEX = /\A[\-\+]?(\d+(\.\d*)?|\.\d+)(E[\-\+]?\d+)?\z/i
 
         # Initialize the FromString Builder object.
         #


### PR DESCRIPTION
In `VALID_DECIMAL128_STRING_REGEX`, a [recent commit](https://github.com/mongodb/bson-ruby/commit/80be3c09665297a55850bf588f0767ac4ee57708#diff-08ce2abf8e4ad4dedd852e5af813144345de9d8c4b9ae052e0204103033947b5) used `\Z` (uppercase). Probably `\z` (lowercase) is the correct one. The current regex will allow `"21.23\n"` as a valid value.

```
$ Matches the end of a line.

\z Matches the end of the string.

\Z Matches the end of the string unless the string ends with a ``\n'', in which case it matches just before the ``\n''.
```

https://ruby-doc.com/docs/ProgrammingRuby/html/language.html#UJ

