### PR TITLE
RUBY-3533 Make BSON::Binary objects comparable

### DIFF
--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -24,6 +24,7 @@ module BSON
   # @since 2.0.0
   class Binary
     include JSON
+    include Comparable
 
     # A binary is type 0x05 in the BSON spec.
     #
@@ -89,6 +90,20 @@ module BSON
       type == other.type && data == other.data
     end
     alias eql? ==
+
+    # Compare this binary object to another object. The two objects must have
+    # the same type for any meaningful comparison.
+    #
+    # @param [ Object ] other The object to compare against.
+    # 
+    # @return [ Integer | nil ] If the objects have the same type, the result
+    #   is -1 if self < other, 0 if self == other, and 1 if self > other. If
+    #   other is not a Binary, or is a Binary of a different type, returns nil.
+    def <=>(other)
+      return nil unless other.is_a?(Binary) && type == other.type
+
+      data <=> other.data
+    end
 
     # Generates a Fixnum hash value for this object.
     #

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -20,17 +20,56 @@ describe BSON::Binary do
   let(:testing1)  { described_class.new("testing") }
   let(:testing2)  { described_class.new("testing") }
   let(:not_testing) { described_class.new("not testing") }
+  let(:testing3) { described_class.new("testing", :user) }
 
-  describe "#eql?" do
-    context "for two equal objects" do
-      it "returns true" do
-        expect(testing1).to eql(testing2)
+  describe "Comparable" do
+    describe "#eql?" do
+      context "for two equal objects" do
+        it "returns true" do
+          expect(testing1).to eql(testing2)
+        end
+      end
+
+      context "for two different objects" do
+        it "returns false" do
+          expect(testing1).not_to eql(not_testing)
+        end
+      end
+
+      context 'for objects with identical data but different types' do
+        it 'returns false' do
+          expect(testing1).not_to eql(testing3)
+        end
       end
     end
 
-    context "for two different objects" do
-      it "returns false" do
-        expect(testing1).not_to eql(not_testing)
+    describe '#<=>' do
+      context 'with a non-Binary object' do
+        it 'returns nil' do
+          expect(testing1 <=> 'bogus').to be_nil
+        end
+      end
+
+      context 'with identical type and data' do
+        it 'returns 0' do
+          expect(testing1 <=> testing2).to be == 0
+        end
+      end
+
+      context 'with mismatched type' do
+        it 'returns nil' do
+          expect(testing1 <=> testing3).to be_nil
+        end
+      end
+
+      context 'with identical type but mismatched data' do
+        it 'returns -1 when a < b' do
+          expect(not_testing <=> testing1).to be == -1
+        end
+
+        it 'returns 1 when a > b' do
+          expect(testing1 <=> not_testing).to be == 1
+        end
       end
     end
   end


### PR DESCRIPTION
Because BSON::Binary instances represent binary data, it ought to be possible to compare their raw binary contents and decide which one would sort before or after another. This PR adds an implementation of `#<=>` to BSON::Binary. As long as both objects have the same binary type, this will compare the raw contents of the two objects, allowing homogeneous lists of BSON::Binary instances to be (e.g.) sorted.