### PR TITLE
TEST: explicitly require stringio

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
 require "ostruct"
+require "stringio"
 require "bson"
 require "json"
 require "rspec"


### PR DESCRIPTION
Since spec/spec_helper.rb uses StringIO class,
make this file explicitly require stringio.