### PR TITLE
RUBY-3557 Mark SecureRandom as Global

### DIFF
--- a/ext/bson/util.c
+++ b/ext/bson/util.c
@@ -170,6 +170,9 @@ VALUE pvt_load_secure_random(VALUE _arg) {
   pvt_SecureRandom = rb_const_get(rb_cObject, rb_intern("SecureRandom"));
   pvt_has_random_number = rb_respond_to(pvt_SecureRandom, rb_intern("random_number"));
 
+  // mark SecureRandom so it does not get moved
+  rb_global_variable(&pvt_SecureRandom);
+
   return Qnil;
 }
 


### PR DESCRIPTION
SecureRandom needs to be marked global so that it cannot be moved during GC compaction. When this happens the `pvt_SecureRandom` may reference a different object, or nothing at all causing a segfault.

I am not quite sure how a test would be written for this since it'd have to be run on its own, and it segfaults the process so the suite wouldn't run. This can be reproduced (on master), and shown resolved (on this branch) with the following:

```
rake compile
bundle console

irb> GC.verify_compaction_references(expand_heap: true, toward: :empty);
irb> BSON::ObjectId.new
```