### PR TITLE
Prep for 5.0.2

### DIFF
--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -16,5 +16,5 @@
 # limitations under the License.
 
 module BSON
-  VERSION = "5.0.1"
+  VERSION = "5.0.2"
 end


### PR DESCRIPTION
Preparing for the release of 5.0.2. Notable changes in this release include:

- [RUBY-3533](https://jira.mongodb.org/browse/RUBY-3533) `BSON::Binary` objects are now instances of `Comparable`, and can be compared and sorted.
- [RUBY-3557](https://jira.mongodb.org/browse/RUBY-3557) Creating a new `BSON::ObjectId` could, due to GC compaction, result in segfaults. Many thanks to Zachery Hostens for identifying the root cause here, and proposing a fix!