### PR TITLE
Add error raise for deep_symbolize_keys!

### DIFF
--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -321,6 +321,10 @@ module BSON
       raise ArgumentError, 'symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #symbolize_keys! on the Hash instance'
     end
 
+    def deep_symbolize_keys!
+      raise ArgumentError, 'deep_symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #deep_symbolize_keys! on the Hash instance'
+    end
+
     # Override the Hash implementation of to_bson_normalized_value.
     #
     # BSON::Document is already of the correct type and already provides

--- a/lib/bson/document.rb
+++ b/lib/bson/document.rb
@@ -322,7 +322,11 @@ module BSON
     end
 
     def deep_symbolize_keys!
-      raise ArgumentError, 'deep_symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #deep_symbolize_keys! on the Hash instance'
+      warn <<~WARN
+        [DEPRECATION] `deep_symbolize_keys!` is not supported on BSON::Document instances.
+        Please convert the document to a Hash first (using `#to_h`), then call `#deep_symbolize_keys!` on the Hash.
+        This will raise an error starting with the v6.0.0 release.
+      WARN
     end
 
     # Override the Hash implementation of to_bson_normalized_value.

--- a/spec/bson/document_as_spec.rb
+++ b/spec/bson/document_as_spec.rb
@@ -52,9 +52,9 @@ describe BSON::Document do
       end
 
       it 'raises ArgumentError' do
-        lambda do
+        expect do
           doc.deep_symbolize_keys!
-        end.should raise_error(ArgumentError, /deep_symbolize_keys! is not supported on BSON::Document instances/)
+        end.to output(/\[DEPRECATION\] `deep_symbolize_keys!` is not supported on BSON::Document instances./).to_stderr
       end
     end
   end

--- a/spec/bson/document_as_spec.rb
+++ b/spec/bson/document_as_spec.rb
@@ -44,4 +44,18 @@ describe BSON::Document do
       end
     end
   end
+
+  describe '#deep_symbolize_keys!' do
+    context 'string keys' do
+      let(:doc) do
+        described_class.new('foo' => 'bar')
+      end
+
+      it 'raises ArgumentError' do
+        lambda do
+          doc.deep_symbolize_keys!
+        end.should raise_error(ArgumentError, /deep_symbolize_keys! is not supported on BSON::Document instances/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Overview

Analogue of this [PR](https://github.com/mongodb/bson-ruby/pull/235)  but for `.deep_symbolize_keys!'

Inspired by few hours debugging why things behave weird

```
[DEVELOPMENT] tags/master-build-29117^0 irb(main):001:0> d = BSON::Document.new(foo: 'bar')
=> {"foo"=>"bar"}
[DEVELOPMENT] tags/master-build-29117^0 irb(main):002:0> d.deep_symbolize_keys!
=> {"foo"=>"bar"}
[DEVELOPMENT] tags/master-build-29117^0 irb(main):003:0> d.symbolize_keys!
(irb):3:in `<main>': symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #symbolize_keys! on the Hash instance (ArgumentError)
```

It will be also great to backport it to 4 major, I can create PR if you'll accept this one. 