### PR TITLE
RUBY-3665 - Fix Rubocop

### DIFF
--- a/.github/workflows/bson-ruby.yml
+++ b/.github/workflows/bson-ruby.yml
@@ -3,6 +3,20 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby 3.4
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4
+          bundler-cache: true
+      - name: Run RuboCop
+        run: bundle exec rubocop --parallel
+
   build:
     name: >-
       ${{ matrix.os }} ${{ matrix.ruby }}
@@ -20,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ 2.7, 3.0, 3.1, 3.2, 3.3, head ]
+        ruby: [ 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, head ]
         include:
           - { os: windows , ruby: mingw }
         exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Exclude:
     - 'spec/shared/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
   Exclude:
     - 'spec/shared/**/*'
     - 'tmp/**/*'
+    - 'vendor/**/*'
 
 Bundler:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,15 @@ group :development, :test do
   # https://github.com/jruby/jruby/wiki/UsingTheJRubyDebugger
   gem 'ruby-debug', platforms: :jruby
 
-  gem 'rubocop', '~> 1.75.5'
-  gem 'rubocop-performance', '~> 1.25.0'
-  gem 'rubocop-rake', '~> 0.7.1'
-  gem 'rubocop-rspec', '~> 3.6.0'
+  # JRuby 9.3 reports RUBY_VERSION as 2.6, and the latest versions of Rubocop
+  # wants 2.7 or higher. It enough to use rubocop only on MRI, so we can skip
+  # it on JRuby.
+  unless RUBY_PLATFORM =~ /java/
+    gem 'rubocop', '~> 1.75.5'
+    gem 'rubocop-performance', '~> 1.25.0'
+    gem 'rubocop-rake', '~> 0.7.1'
+    gem 'rubocop-rspec', '~> 3.6.0'
+  end
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -24,14 +24,10 @@ group :development, :test do
   # https://github.com/jruby/jruby/wiki/UsingTheJRubyDebugger
   gem 'ruby-debug', platforms: :jruby
 
-  # Ruby 2.5 wants an older version of rubocop. Rather than try to
-  # please everybody, we'll just not install rubocop for Ruby 2.5.
-  if RUBY_VERSION > "2.5.99"
-    gem 'rubocop', '~> 1.45.1'
-    gem 'rubocop-performance', '~> 1.16.0'
-    gem 'rubocop-rake', '~> 0.6.0'
-    gem 'rubocop-rspec', '~> 2.18.1'
-  end
+  gem 'rubocop', '~> 1.75.5'
+  gem 'rubocop-performance', '~> 1.25.0'
+  gem 'rubocop-rake', '~> 0.7.1'
+  gem 'rubocop-rspec', '~> 3.6.0'
 end
 
 group :test do

--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+# rubocop:todo all
 # Copyright (C) 2009-2020 MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/object_id.rb
+++ b/lib/bson/object_id.rb
@@ -360,7 +360,7 @@ module BSON
       # NUM2UINT. Further, the spec dictates that the time component of an
       # ObjectID must be no more than 4 bytes long, so the spec itself is
       # constrained in this regard.
-      MAX_INTEGER = 2 ** 32
+      MAX_INTEGER = 2**32
 
       # Returns an integer timestamp (seconds since the Epoch). Primarily used
       # by the generator to produce object ids.

--- a/lib/bson/regexp.rb
+++ b/lib/bson/regexp.rb
@@ -99,16 +99,16 @@ module BSON
     end
 
     def bson_extended
-      (options & ::Regexp::EXTENDED).zero? ? NO_VALUE : EXTENDED_VALUE
+      options.nobits?(::Regexp::EXTENDED) ? NO_VALUE : EXTENDED_VALUE
     end
 
     def bson_ignorecase
-      (options & ::Regexp::IGNORECASE).zero? ? NO_VALUE : IGNORECASE_VALUE
+      options.nobits?(::Regexp::IGNORECASE) ? NO_VALUE : IGNORECASE_VALUE
     end
 
     def bson_dotall
       # Ruby Regexp's MULTILINE is equivalent to BSON's dotall value
-      (options & ::Regexp::MULTILINE).zero? ? NO_VALUE : NEWLINE_VALUE
+      options.nobits?(::Regexp::MULTILINE) ? NO_VALUE : NEWLINE_VALUE
     end
 
     # Represents the raw values for the regular expression.

--- a/lib/bson/vector.rb
+++ b/lib/bson/vector.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+# rubocop:todo all
 # Copyright (C) 2025-present MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bson/vector.rb
+++ b/lib/bson/vector.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# rubocop:todo all
+
 # Copyright (C) 2025-present MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@
 module BSON
   # Vector of numbers along with metadata for binary interoperability.
   class Vector < ::Array
-
     # @return [ Integer ] The data type stored in the vector.
     attr_reader :dtype
 

--- a/spec/runners/binary_vector.rb
+++ b/spec/runners/binary_vector.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:todo all
 require 'runners/common_driver'
 
 module BSON

--- a/spec/runners/binary_vector.rb
+++ b/spec/runners/binary_vector.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # rubocop:todo all
 require 'runners/common_driver'
 

--- a/spec/runners/binary_vector.rb
+++ b/spec/runners/binary_vector.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# rubocop:todo all
+
 require 'runners/common_driver'
 
 module BSON
@@ -26,7 +26,6 @@ module BSON
     end
 
     class Test
-
       attr_reader :canonical_bson, :description, :dtype, :padding, :vector
 
       def initialize(spec, test)
@@ -49,7 +48,6 @@ module BSON
         bson_bytes = decode_hex(@canonical_bson)
         buffer = BSON::ByteBuffer.new(bson_bytes)
         BSON::Document.from_bson(buffer)
-
       end
 
       def canonical_bson_from_document(use_vector_type: false, validate_vector_data: false)


### PR DESCRIPTION
Fixes RUBY-3665

This PR fixes and upgrade Rubocop, which is not currently passing in this repo.

Specific changes:
- Fix or skip cops so that Rubocop is green
- Upgrade Rubocop and related Rubocop gems
- Set min Ruby target version to 2.6 to match gemspec min Ruby version
- Remove conditional logic for Ruby < 2.6
- Add Rubocop step to Github Actions CI
- Add test coverage for Ruby 3.4 coverage to Github Actions while we're here

Please also ensure Rubocop is running in Nevergreen.
