### PR TITLE
WIP - RUBY-3671 - Hash should honor BSON::Registry

### DIFF
--- a/lib/bson/hash.rb
+++ b/lib/bson/hash.rb
@@ -167,7 +167,7 @@ module BSON
       #
       # @return [ Hash ] the hash parsed from the buffer
       def parse_hash_from_buffer(buffer, **options)
-        hash = Document.allocate
+        hash = ruby_base_type.allocate
         start_position = buffer.read_position
         expected_byte_size = buffer.get_int32
 
@@ -199,6 +199,12 @@ module BSON
                   end
           hash.store(field, value)
         end
+      end
+
+      private
+
+      def ruby_base_type
+        BSON::Registry.get(BSON_TYPE)
       end
     end
 

--- a/lib/bson/registry.rb
+++ b/lib/bson/registry.rb
@@ -42,7 +42,7 @@ module BSON
     #
     # @since 2.0.0
     def get(byte, field = nil)
-      if type = MAPPINGS[byte] || (byte.is_a?(String) && type = MAPPINGS[byte.ord])
+      if (type = MAPPINGS[byte]) || (byte.is_a?(String) && (type = MAPPINGS[byte.ord]))
         type
       else
         handle_unsupported_type!(byte, field)


### PR DESCRIPTION
Fixes RUBY-3671

There is a `BSON::Registry` which determines how BSON is deserialized. Mongoid has this code:

```ruby
if allow_decimal128
  BSON::Registry.register(BSON::Decimal128::BSON_TYPE, BSON::Decimal128)
else
  BSON::Registry.register(BSON::Decimal128::BSON_TYPE, BigDecimal)
end 
```

However, BSON gem does not honor this registry for for `Hash`, it always deserializes as `BSON::Document`, even when the registry is set to `Hash`.

 