### PR TITLE
Update bson-ruby.yml workflow

### DIFF
--- a/.github/workflows/bson-ruby.yml
+++ b/.github/workflows/bson-ruby.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   rubocop:
@@ -8,7 +8,8 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
@@ -34,27 +35,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, head ]
+        ruby: [ 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         include:
-          - { os: windows , ruby: mingw }
+          - { os: windows , ruby: ucrt }
         exclude:
           - { os: windows , ruby: head }
-          - { os: windows , ruby: 3.1 }
 
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: load ruby, ragel
+      - name: load ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: 2
-
-      - name: bundle install
-        run:  bundle install --jobs 4 --retry 3
+          rubygems: latest
+          bundler-cache: true
 
       - name: compile
         run:  bundle exec rake compile


### PR DESCRIPTION
Updates the main CI file `bson-ruby.yml`

1. Add `workflow_dispatch` - this is used in other workflows here.  It allows maintainers to force a CI run.  It also does the same for users with forks of this repo.  Helpful for when changes to dependencies (or Ruby) happen that may affect this.

2. Update `actions/checkout` to `actions/checkout@v4`.  Used in other workflows

3. Add quotes to 3.0.  Actions' yaml parser truncates decimal zeros.  So, unquoted `3.0` will specify `3`, and unquoted `3.10` will specify `3.1`.  See [recent workflow](https://github.com/mongodb/bson-ruby/actions/runs/14909061493/job/41878540919#step:3:24).

3. WIndows - use `ucrt` instead of `mingw`.  Ruby 3.0 was the last publicly available `mingw` build.  Or, Ruby 3.5 will be released as a `ucrt` build.  Hence, better to test with a Ruby head `ucrt`.

4. There are quite a few items installed via bundler, use caching.