### PR TITLE
RUBY-3675 Use append_cflags over modifying CFLAGS directly

### DIFF
--- a/ext/bson/extconf.rb
+++ b/ext/bson/extconf.rb
@@ -3,6 +3,6 @@
 
 require 'mkmf'
 
-$CFLAGS << ' -Wall -g -std=c99'
+append_cflags(["-Wall", "-g", "-std=c99"])
 
 create_makefile('bson_native')


### PR DESCRIPTION
- Allows installing bson gem on systems with GCC 15
- Fixes https://jira.mongodb.org/browse/RUBY-3675

References:

- Ruby Lang - https://bugs.ruby-lang.org/issues/21290#61
- io-event gem
  - bug report: https://github.com/socketry/io-event/issues/136
  - bugfix patch (+6 / -6): https://github.com/socketry/io-event/pull/137/commits/d08576119ccd48900850b833fe853f39f3d604b7
- ed25519 gem
  - bug report: https://github.com/RubyCrypto/ed25519/issues/44
  - bugfix patch (+1 / -1): https://github.com/RubyCrypto/ed25519/pull/45/files#diff-805cf1ea9824de19b94dce429b3a3544fd9cb0b3cc278e571776c7d672cc1dfa
- jaro_winkler gem
  - bug report: https://github.com/tonytonyjan/jaro_winkler/issues/61
  - bugfix patch (+1 / -1): https://github.com/tonytonyjan/jaro_winkler/pull/62/files#diff-594397402316a8262174f2dc8159b5a35560516bd3cd355b1bf657a6e0a973ce

<sub>

Please help me support open source by [sponsoring me](https://github.com/sponsors/pboling) - @pboling

</sub>