### PR TITLE
RUBY-3643 Update for new release process

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup Ruby
       if: matrix.build-mode == 'manual'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,32 +2,17 @@ name: "BSON Release"
 run-name: "BSON Release for ${{ github.ref }}"
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Whether this is a dry run or not
-        required: true
-        default: true
-        type: boolean
+  # for auto-deploy when merging a release-candidate PR
+  pull_request:
+    types: [ closed ]
+
+  # for manual release trigger: "/release" in a comment on a merged
+  # release-candidate PR (useful if the auto-deploy fails)
+  issue_comment:
+    types: [ created ]
 
 env:
   SILK_ASSET_GROUP: bson-ruby
-  RELEASE_MESSAGE_TEMPLATE: |
-    Version {0} of [BSON for Ruby](https://rubygems.org/gems/bson) is now available.
-
-    **Release Highlights**
-
-    TODO: one or more paragraphs describing important changes in this release
-
-    **Documentation**
-
-    Documentation is available at [MongoDB.com](https://www.mongodb.com/docs/ruby-driver/current/tutorials/bson/).
-
-    **Installation**
-
-    You may install this version via RubyGems, with:
-
-    gem install --version {0} bson
 
 permissions:
   # required for all workflows
@@ -38,6 +23,7 @@ permissions:
 
   # only required for workflows in private repositories
   actions: read
+  pull-request: read
   contents: write
 
   # required by the mongodb-labs/drivers-github-tools/setup@v2 step
@@ -45,126 +31,54 @@ permissions:
   id-token: write
 
 jobs:
+  check:
+    name: "Check Release"
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.check.outputs.message }}
+      ref: ${{ steps.check.outputs.ref }}
+    steps:
+      - name: "Run the check action"
+        id: check
+        uses: jamis/drivers-github-tools/ruby/pr-check@ruby-3643-update-release-process
+
   build:
     name: "Build Gems"
+    needs: check
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', jruby ]
+        ruby: [ 'ruby-3.2', 'jruby-9.4' ]
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - name: "Run the build action"
+        uses: jamis/drivers-github-tools/ruby/build@ruby-3643-update-release-process
         with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Set output gem file name
-        shell: bash
-        run: |
-          echo "GEM_FILE_NAME=$(bundle exec rake gem_file_name)" >> "$GITHUB_ENV"
-
-      - name: Build the gem
-        shell: bash
-        run: bundle exec rake build
-
-      - name: Save the generated gem file for later
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.GEM_FILE_NAME }}
-          path: ${{ env.GEM_FILE_NAME }}
-          retention-days: 1
-          overwrite: true
+          app_id: ${{ vars.APP_ID }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          artifact: ${{ matrix.ruby }}
+          gem_name: bson
+          ruby_version: ${{ matrix.ruby }}
+          ref: ${{ needs.check.outputs.ref }}
 
   publish:
     name: Publish Gems
-    needs: build
+    needs: [ check, build ]
     environment: release
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+      - name: "Run the publish action"
+        uses: jamis/drivers-github-tools/ruby/publish@ruby-3643-update-release-process
         with:
           app_id: ${{ vars.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-
-      - name: Get the release version
-        shell: bash
-        run: echo "RELEASE_VERSION=$(bundle exec rake version)" >> "$GITHUB_ENV"
-
-      - name: Setup GitHub tooling for DBX Drivers
-        uses: mongodb-labs/drivers-github-tools/setup@v2
-        with:
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
-
-      - name: Fetch the gem artifacts
-        uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-
-      - name: Sign the gems
-        uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
-        with:
-          filenames: '*.gem'
-
-      - name: Generate SSDLC Reports
-        uses: mongodb-labs/drivers-github-tools/full-report@v2
-        with:
+          dry_run: false
+          gem_name: bson
           product_name: BSON for Ruby
-          release_version: ${{ env.RELEASE_VERSION }}
-          dist_filenames: '*.gem'
-          silk_asset_group: bson-ruby
-
-      - name: Create the tag
-        uses: mongodb-labs/drivers-github-tools/tag-version@v2
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          tag_template: "v${VERSION}"
-          tag_message_template: "Release tag for v${VERSION}"
-
-      - name: Create a new release
-        shell: bash
-        run: gh release create v${{ env.RELEASE_VERSION }} --title ${{ env.RELEASE_VERSION }} --generate-notes --draft
-
-      - name: Capture the changelog
-        shell: bash
-        run: gh release view v${{ env.RELEASE_VERSION }} --json body --template '{{ .body }}' >> changelog
-
-      - name: Prepare release message
-        shell: bash
-        run: |
-          echo "${{ format(env.RELEASE_MESSAGE_TEMPLATE, env.RELEASE_VERSION) }}" > release-message
-          cat changelog >> release-message
-
-      - name: Update release information
-        shell: bash
-        run: |
-          echo "RELEASE_URL=$(gh release edit v${{ env.RELEASE_VERSION }} --notes-file release-message)" >> "$GITHUB_ENV"
-
-      - name: Upload release artifacts
-        shell: bash
-        run: gh release upload v${{ env.RELEASE_VERSION }} *.gem ${{ env.RELEASE_ASSETS }}/*.sig
-
-      - name: Upload S3 assets
-        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          product_name: 'bson-ruby'
-          dry_run: ${{ inputs.dry_run }}
-
-      - name: Publish the gems
-        uses: rubygems/release-gem@v1
-        if: inputs.dry_run == false
-        with:
-          await-release: false
+          product_id: mongodb-ruby-driver
+          release_message: ${{ needs.check.outputs.message }}
+          silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
+          ref: ${{ needs.check.outputs.ref }}

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,8 @@ require "rake/extensiontask"
 require "rspec/core/rake_task"
 require 'fileutils'
 
+load 'spec/shared/lib/tasks/candidate.rake'
+
 def jruby?
   defined?(JRUBY_VERSION)
 end

--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -1,20 +1,9 @@
 # frozen_string_literal: true
-# rubocop:todo all
-
-# Copyright (C) 2009-2020 MongoDB Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 module BSON
-  VERSION = "5.0.2"
+  # The current version of the library.
+  #
+  # NOTE: this file is automatically updated via `rake candidate:create`.
+  # Manual changes to this file may be overwritten by that rake task.
+  VERSION = '5.0.2'
 end

--- a/product.yml
+++ b/product.yml
@@ -1,0 +1,6 @@
+---
+name: BSON for Ruby
+package: bson
+version:
+  number: 5.0.2
+  file: lib/bson/version.rb


### PR DESCRIPTION
As part of RUBY-3643 (updating the release process), this adds some experimental changes to the release process for BSON-Ruby. Notably:

- Adds `spec/shared` to gain access to the new `candidate` rake tasks.
- Adds `product.yml` for compatibility with the new `candidate` rake tasks.
- Updates `.github/workflows/release.yml` to reference the new/updated (experimental) `pr-check`, `build`, and `publish` actions.

This includes no user-facing changes.