### PR TITLE
Fix typo in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
   # only required for workflows in private repositories
   actions: read
-  pull-request: read
+  pull-requests: read
   contents: write
 
   # required by the mongodb-labs/drivers-github-tools/setup@v2 step


### PR DESCRIPTION
There was a typo in release.yml.

Probably not the last. (It would sure be nice if github provided a way to validate workflow files before committing...)