### PR TITLE
Release candidate for 5.1.0

### DIFF
--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -5,5 +5,5 @@ module BSON
   #
   # NOTE: this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file may be overwritten by that rake task.
-  VERSION = '5.0.2'
+  VERSION = "5.1.0"
 end

--- a/product.yml
+++ b/product.yml
@@ -2,5 +2,5 @@
 name: BSON for Ruby
 package: bson
 version:
-  number: 5.0.2
+  number: 5.1.0
   file: lib/bson/version.rb


### PR DESCRIPTION
BSON for Ruby 5.1.0 is a new minor release.

Install it via RubyGems at a command-line:

~~~
gem install -v 5.1.0 bson
~~~

Or by adding it to your Gemfile:

~~~
gem 'bson', '5.1.0'
~~~

Notable changes in this release are:

# New Features

* [RUBY-3521](https://jira.mongodb.org/browse/RUBY-3521) Add binary vector support ([PR](https://github.com/mongodb/bson-ruby/pull/344))
* Warn on BSON::Document#deep_symbolize_keys! ([PR](https://github.com/mongodb/bson-ruby/pull/346))

# Bug Fixes

* TEST: explicitly require stringio ([PR](https://github.com/mongodb/bson-ruby/pull/340))
* [RUBY-3665](https://jira.mongodb.org/browse/RUBY-3665) - Fix Rubocop ([PR](https://github.com/mongodb/bson-ruby/pull/349))
* Update bson-ruby.yml workflow ([PR](https://github.com/mongodb/bson-ruby/pull/354))
* [RUBY-3675](https://jira.mongodb.org/browse/RUBY-3675) Use append_cflags over modifying CFLAGS directly ([PR](https://github.com/mongodb/bson-ruby/pull/355))
