### PR TITLE
Release Candidate for 5.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
   build:
     name: "Build Gems"
     needs: check
+    environment: release
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 5.1.0 of the `bson` gem - a fully featured [BSON specification](https://bsonspec.org/) implementation in Ruby.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows:

~~~
gem install -v 5.1.0 bson
~~~

or simply add it to your `Gemfile`:

~~~
gem 'bson', '5.1.0'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# Release Notes

## New Features

* [RUBY-3521](https://jira.mongodb.org/browse/RUBY-3521) Add binary vector support ([PR](https://github.com/mongodb/bson-ruby/pull/344))
* Warn on `BSON::Document#deep_symbolize_keys!` ([PR](https://github.com/mongodb/bson-ruby/pull/346))

## Bug Fixes

* TEST: explicitly require stringio ([PR](https://github.com/mongodb/bson-ruby/pull/340))
* [RUBY-3665](https://jira.mongodb.org/browse/RUBY-3665) - Fix Rubocop ([PR](https://github.com/mongodb/bson-ruby/pull/349))
* Update bson-ruby.yml workflow ([PR](https://github.com/mongodb/bson-ruby/pull/354))
* [RUBY-3675](https://jira.mongodb.org/browse/RUBY-3675) Use `append_cflags` over modifying CFLAGS directly ([PR](https://github.com/mongodb/bson-ruby/pull/355))
