### PR TITLE
Release candidate for 5.1.1

### DIFF
--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -5,5 +5,5 @@ module BSON
   #
   # NOTE: this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file may be overwritten by that rake task.
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a fully featured [BSON specification](https://bsonspec.org/) implem
 package: bson
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 5.1.0
+  number: 5.1.1
   file: lib/bson/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 5.1.1
of the `bson` gem - a fully featured [BSON specification](https://bsonspec.org/) implementation in Ruby.
This is a new patch release in the 5.1.x series of BSON for Ruby.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 5.1.1 bson
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'bson', '5.1.1'
~~~

Have any feedback? Click on through to MongoDB's JIRA and
[open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

