### PR TITLE
Final (?) tweaks to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ run-name: "BSON Release for ${{ github.ref }}"
 on:
   # for auto-deploy when merging a release-candidate PR
   push:
-    - 'master'
-    - '*-stable'
+    branches:
+      - 'master'
+      - '*-stable'
 
   # for manual release
   workflow_dispatch:


### PR DESCRIPTION
It turns out that GitHub will not present project variables and secrets to `pull_request` triggers (for security reasons). To work around this, I've changed the workflow to instead trigger on pushes to the master and stable branches.

I've also added the ability to manually trigger a release workflow by giving the number of the (merged) candidate pull request that you want to release.