### PR TITLE
Only try to load candidate tasks if the submodule has been loaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,9 @@ require "rake/extensiontask"
 require "rspec/core/rake_task"
 require 'fileutils'
 
-load 'spec/shared/lib/tasks/candidate.rake'
+if File.exist?('./spec/shared/lib/tasks/candidate.rake')
+  load './spec/shared/lib/tasks/candidate.rake'
+end
 
 def jruby?
   defined?(JRUBY_VERSION)


### PR DESCRIPTION
Currently, projects that depend on bson-ruby's master branch (e.g. their Gemfile points to the bson-ruby repo) fail when the `rake compile` step tries to load the candidate tasks from spec/shared, because rubygems does not try to prepare any submodules.

This makes the Rakefile safe to run even when the spec/shared submodule has not been loaded.