### PR TITLE
RUBY-3869 Validate Binary subtype 0x02 outer/inner length on decode

### DIFF
--- a/lib/bson/binary.rb
+++ b/lib/bson/binary.rb
@@ -306,7 +306,20 @@ module BSON
         type = type_byte
       end
 
-      length = buffer.get_int32 if type == :old
+      if type == :old
+        inner_length = buffer.get_int32
+        unless inner_length == length - 4
+          raise Error::BSONDecodeError,
+                "BSON binary subtype 0x02 length mismatch: outer=#{length}, inner=#{inner_length}"
+        end
+        length = inner_length
+      end
+
+      if length.negative?
+        raise Error::BSONDecodeError,
+              "BSON binary length is negative: #{length}"
+      end
+
       data = buffer.get_bytes(length)
       new(data, type)
     end

--- a/spec/bson/binary_spec.rb
+++ b/spec/bson/binary_spec.rb
@@ -204,6 +204,58 @@ describe BSON::Binary do
           /BSON data contains unsupported binary subtype 0x10/)
       end
     end
+
+    context 'when subtype 0x02 inner length is too long' do
+      let(:bson) do
+        ([6].pack('l<') + 2.chr + [3].pack('l<') + 'xxx').force_encoding('BINARY')
+      end
+
+      it 'raises BSONDecodeError' do
+        expect { obj }.to raise_error(
+          BSON::Error::BSONDecodeError,
+          /length mismatch.*outer=6.*inner=3/
+        )
+      end
+    end
+
+    context 'when subtype 0x02 inner length is too short' do
+      let(:bson) do
+        ([6].pack('l<') + 2.chr + [1].pack('l<') + 'xxx').force_encoding('BINARY')
+      end
+
+      it 'raises BSONDecodeError' do
+        expect { obj }.to raise_error(
+          BSON::Error::BSONDecodeError,
+          /length mismatch.*outer=6.*inner=1/
+        )
+      end
+    end
+
+    context 'when subtype 0x02 inner length is negative' do
+      let(:bson) do
+        ([6].pack('l<') + 2.chr + [-1].pack('l<') + 'xx').force_encoding('BINARY')
+      end
+
+      it 'raises BSONDecodeError' do
+        expect { obj }.to raise_error(
+          BSON::Error::BSONDecodeError,
+          /length mismatch.*outer=6.*inner=-1/
+        )
+      end
+    end
+
+    context 'when non-old subtype outer length is negative' do
+      let(:bson) do
+        ([-1].pack('l<') + 0.chr).force_encoding('BINARY')
+      end
+
+      it 'raises BSONDecodeError' do
+        expect { obj }.to raise_error(
+          BSON::Error::BSONDecodeError,
+          /length is negative.*-1/
+        )
+      end
+    end
   end
 
   describe "#to_bson/#from_bson" do


### PR DESCRIPTION
## Description
`BSON::Binary.from_bson` did not cross-check the outer/inner length fields for subtype 0x02 (`:old`), and never explicitly rejected negative lengths. Malformed payloads were caught only by incidental effects (the leftover bytes happening to misalign the next-field type byte, or a wrap-around triggering the C `get_bytes` overrun guard).

This change adds an explicit cross-check (`inner_length == outer_length - 4`) and an explicit negative-length guard, both raising `BSON::Error::BSONDecodeError` with a clear message.

## What changed
- `lib/bson/binary.rb` — `from_bson` now raises on length mismatch and negative length instead of relying on incidental rejection.
- `spec/bson/binary_spec.rb` — unit specs covering the four error paths (inner too long, inner too short, inner negative, non-old outer negative). The bson-corpus tests assert only that something raises; these tests pin the exact error class and message.

## Cross-driver reference
Matches the existing Python driver behavior in `bson/__init__.py::_get_binary`:
```python
if subtype == 2:
    length2 = _UNPACK_INT_FROM(data, position)[0]
    position += 4
    if length2 != length - 4:
        raise InvalidBSON("invalid binary (st 2) - lengths don't match!")
    length = length2
```

## Test plan
- [x] `bundle exec rspec spec/bson/binary_spec.rb spec/spec_tests/corpus_spec.rb` — 2613 examples, 0 failures.
- [x] `bundle exec rubocop lib/bson/binary.rb spec/bson/binary_spec.rb` — no offenses.

## Jira
https://jira.mongodb.org/browse/RUBY-3869