### PR TITLE
RUBY-3872 Fix put_double TypeError message regex for Ruby head

### DIFF
--- a/spec/bson/byte_buffer_write_spec.rb
+++ b/spec/bson/byte_buffer_write_spec.rb
@@ -508,7 +508,7 @@ describe BSON::ByteBuffer do
       it 'raises TypeError' do
         expect do
           modified
-        end.to raise_error(TypeError, /no implicit conversion to float from string|ClassCastException:.*RubyString cannot be cast to.*RubyFloat/)
+        end.to raise_error(TypeError, /no implicit conversion to float from string|no implicit conversion of String into Float|ClassCastException:.*RubyString cannot be cast to.*RubyFloat/)
         expect(buffer.write_position).to eq(0)
       end
     end


### PR DESCRIPTION
## Changes

Update the `put_double` TypeError message regex in `spec/bson/byte_buffer_write_spec.rb` to accept both the old and new Ruby TypeError wording.

Ruby head changed the message from:
- `no implicit conversion to float from string` (Ruby ≤ 3.4)

to:
- `no implicit conversion of String into Float` (Ruby head)

The regex now covers both MRI forms plus the existing JRuby `ClassCastException` form. No production code changes.

**Files changed**
- `spec/bson/byte_buffer_write_spec.rb` — regex on line 511 extended

## Test plan

- [x] `bundle exec rspec spec/bson/byte_buffer_write_spec.rb` — 87 examples, 0 failures

Jira: https://jira.mongodb.org/browse/RUBY-3872