### PR TITLE
Release candidate for 5.2.1

### DIFF
--- a/lib/bson/version.rb
+++ b/lib/bson/version.rb
@@ -5,5 +5,5 @@ module BSON
   #
   # NOTE: this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file may be overwritten by that rake task.
-  VERSION = '5.2.0'
+  VERSION = '5.2.1'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a fully featured [BSON specification](https://bsonspec.org/) implem
 package: bson
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 5.2.0
+  number: 5.2.1
   file: lib/bson/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 5.2.1 of the `bson` gem - a fully featured [BSON specification](https://bsonspec.org/) implementation in Ruby. This is a new patch release in the 5.2.x series of BSON for Ruby.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 5.2.1 bson
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'bson', '5.2.1'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# New Features

* [RUBY-3667](https://jira.mongodb.org/browse/RUBY-3667) BSON::ObjectId(object_id) returns its argument when it is already an ObjectId ([PR](https://github.com/mongodb/bson-ruby/pull/374))

# Bug Fixes

* [RUBY-3535](https://jira.mongodb.org/browse/RUBY-3535) Remove `if RUBY_VERSION` from gemspec ([PR](https://github.com/mongodb/bson-ruby/pull/366))
* [RUBY-3860](https://jira.mongodb.org/browse/RUBY-3860) Cap BSON decode nesting depth at 200 ([PR](https://github.com/mongodb/bson-ruby/pull/369))
* [RUBY-3869](https://jira.mongodb.org/browse/RUBY-3869) Validate Binary subtype 0x02 outer/inner length on decode ([PR](https://github.com/mongodb/bson-ruby/pull/370))
* [RUBY-3893](https://jira.mongodb.org/browse/RUBY-3893) Fix heap use-after-free in put_array ([PR](https://github.com/mongodb/bson-ruby/pull/371))
* [RUBY-3894](https://jira.mongodb.org/browse/RUBY-3894) Fix heap buffer overflow in put_string and related methods ([PR](https://github.com/mongodb/bson-ruby/pull/372))
* [RUBY-3872](https://jira.mongodb.org/browse/RUBY-3872) Fix put_double TypeError message regex for Ruby head ([PR](https://github.com/mongodb/bson-ruby/pull/373))
